### PR TITLE
[codex] add blog search overlay

### DIFF
--- a/src/lib/component/PostList.svelte
+++ b/src/lib/component/PostList.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { getFullTitle, type Post } from '$lib/posts';
+  import { getFullTitle, type PostListItem } from '$lib/posts';
   import type { Tag } from '$lib/posts/tags';
   import { formatDate2JpStyle } from '$lib/util';
   import TagList from './TagList.svelte';
 
   interface Props {
     /** 表示するポストの配列 */
-    posts: Post[];
+    posts: PostListItem[];
     /** タグページの場合のタグ名 */
     tag?: Tag;
     /** 現在のページ数（1始まり） */

--- a/src/lib/component/SearchablePostList.svelte
+++ b/src/lib/component/SearchablePostList.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { browser } from '$app/environment';
+  import { pushState } from '$app/navigation';
   import { resolve } from '$app/paths';
+  import { page } from '$app/state';
   import { onMount, tick } from 'svelte';
   import { fade, fly } from 'svelte/transition';
+  import type { Page } from '@sveltejs/kit';
   import type { Post } from '$lib/posts';
   import type { BlogSearchResults } from '$lib/posts/search';
   import type { Tag } from '$lib/posts/tags';
@@ -17,6 +20,10 @@
     currentPageNumber: number;
     totalNumberOfPages: number;
   }
+
+  type SearchPageState = Page['state'] & {
+    blogSearchOpen?: boolean;
+  };
 
   let {
     heading,
@@ -36,6 +43,8 @@
   let isSearchLoading = $state(false);
   let focusRestoreTarget: HTMLElement | null = null;
   let searchLoadPromise: Promise<void> | null = null;
+  let hasSearchHistoryEntry = false;
+  let isClosingSearchHistory = false;
 
   const emptySearchResults: BlogSearchResults = {
     articles: [],
@@ -84,16 +93,28 @@
     return searchLoadPromise;
   };
 
+  const pushSearchHistoryEntry = () => {
+    if (!browser || hasSearchHistoryEntry) return;
+
+    pushState('', { ...(page.state as SearchPageState), blogSearchOpen: true });
+    hasSearchHistoryEntry = true;
+  };
+
+  const isSearchPageState = () => (page.state as SearchPageState).blogSearchOpen === true;
+
   const openSearch = async ({
     restoreFocusTarget = null,
-    selectQuery = true
+    selectQuery = true,
+    pushHistory = true
   }: {
     restoreFocusTarget?: HTMLElement | null;
     selectQuery?: boolean;
+    pushHistory?: boolean;
   } = {}) => {
     if (!isSearchOpen) {
       focusRestoreTarget = restoreFocusTarget;
       isSearchOpen = true;
+      if (pushHistory) pushSearchHistoryEntry();
     }
     void loadSearch();
 
@@ -102,7 +123,21 @@
     if (selectQuery) searchInput?.select();
   };
 
-  const closeSearch = async ({ restoreFocus = false }: { restoreFocus?: boolean } = {}) => {
+  const closeSearch = async ({
+    restoreFocus = false,
+    syncHistory = true
+  }: {
+    restoreFocus?: boolean;
+    syncHistory?: boolean;
+  } = {}) => {
+    const shouldRestoreHistory = browser && syncHistory && hasSearchHistoryEntry;
+
+    if (shouldRestoreHistory) {
+      isClosingSearchHistory = true;
+      hasSearchHistoryEntry = false;
+      history.back();
+    }
+
     isSearchOpen = false;
     await tick();
 
@@ -140,8 +175,35 @@
     };
 
     window.addEventListener('keydown', handleKeydown);
+    const handlePopstate = () => {
+      if (isClosingSearchHistory) {
+        isClosingSearchHistory = false;
+        return;
+      }
+
+      window.setTimeout(() => {
+        if (isSearchPageState()) {
+          hasSearchHistoryEntry = true;
+          openSearch({ restoreFocusTarget: searchTrigger, pushHistory: false });
+          return;
+        }
+
+        if (isSearchOpen) {
+          hasSearchHistoryEntry = false;
+          closeSearch({ restoreFocus: true, syncHistory: false });
+        }
+      });
+    };
+
+    window.addEventListener('popstate', handlePopstate);
+    if (isSearchPageState()) {
+      hasSearchHistoryEntry = true;
+      openSearch({ restoreFocusTarget: searchTrigger, pushHistory: false });
+    }
+
     return () => {
       window.removeEventListener('keydown', handleKeydown);
+      window.removeEventListener('popstate', handlePopstate);
     };
   });
 
@@ -278,7 +340,7 @@
                         <a
                           href={resolve('/post/[slug]', { slug: article.slug })}
                           class="article-result"
-                          onclick={() => closeSearch()}
+                          onclick={() => closeSearch({ syncHistory: false })}
                         >
                           <div class="article-result-meta">
                             <span class="match-label">{article.matchedFieldLabel}</span>
@@ -309,7 +371,7 @@
                         <a
                           href={resolve('/tag/[tag=tag]', { tag: composer.tag })}
                           class="compact-result"
-                          onclick={() => closeSearch()}
+                          onclick={() => closeSearch({ syncHistory: false })}
                         >
                           <strong>{composer.shortName}</strong>
                           <span>{composer.fullName}</span>
@@ -329,7 +391,7 @@
                         <a
                           href={resolve('/tag/[tag=tag]', { tag: concert.tag })}
                           class="compact-result"
-                          onclick={() => closeSearch()}
+                          onclick={() => closeSearch({ syncHistory: false })}
                         >
                           <strong>{concert.title}</strong>
                           <span>{formatDate2JpStyle(concert.date)}</span>
@@ -349,7 +411,7 @@
                         <a
                           href={resolve('/tag/[tag=tag]', { tag: entry.tag })}
                           class="compact-result"
-                          onclick={() => closeSearch()}
+                          onclick={() => closeSearch({ syncHistory: false })}
                         >
                           <strong>#&thinsp;{entry.tag}</strong>
                           <span>タグページを開く</span>
@@ -673,7 +735,6 @@
 
   @media (max-width: 576px) {
     .post-list-header {
-      flex-direction: column;
       gap: calc(var(--spacing-unit) * 3);
     }
 

--- a/src/lib/component/SearchablePostList.svelte
+++ b/src/lib/component/SearchablePostList.svelte
@@ -2,8 +2,9 @@
   import { browser } from '$app/environment';
   import { resolve } from '$app/paths';
   import { onMount, tick } from 'svelte';
+  import { fade, fly } from 'svelte/transition';
   import type { Post } from '$lib/posts';
-  import { searchBlog } from '$lib/posts/search';
+  import type { BlogSearchResults } from '$lib/posts/search';
   import type { Tag } from '$lib/posts/tags';
   import { formatDate2JpStyle } from '$lib/util';
   import PostList from './PostList.svelte';
@@ -28,18 +29,60 @@
 
   let isSearchOpen = $state(false);
   let searchQuery = $state('');
-  let searchTrigger = $state<HTMLInputElement | null>(null);
+  let searchTrigger = $state<HTMLButtonElement | null>(null);
   let searchInput = $state<HTMLInputElement | null>(null);
   let searchDialog = $state<HTMLDivElement | null>(null);
+  let searchBlogFn = $state<typeof import('$lib/posts/search').searchBlog | null>(null);
+  let isSearchLoading = $state(false);
   let focusRestoreTarget: HTMLElement | null = null;
+  let searchLoadPromise: Promise<void> | null = null;
 
-  const searchResults = $derived(searchBlog(searchQuery));
+  const emptySearchResults: BlogSearchResults = {
+    articles: [],
+    tags: [],
+    composers: [],
+    concerts: []
+  };
+  const trimmedSearchQuery = $derived(searchQuery.trim());
+  const searchResults = $derived(searchBlogFn ? searchBlogFn(searchQuery) : emptySearchResults);
   const hasAnyResults = $derived(
     searchResults.articles.length > 0 ||
       searchResults.tags.length > 0 ||
       searchResults.composers.length > 0 ||
       searchResults.concerts.length > 0
   );
+  const resultCount = $derived(
+    searchResults.articles.length +
+      searchResults.tags.length +
+      searchResults.composers.length +
+      searchResults.concerts.length
+  );
+  const resultStatusText = $derived(
+    isSearchLoading && searchBlogFn === null
+      ? '検索を読み込んでいます。'
+      : trimmedSearchQuery.length === 0
+        ? ''
+        : hasAnyResults
+          ? `${resultCount}件の候補があります。`
+          : `「${searchQuery}」に一致する結果は見つかりませんでした。`
+  );
+
+  const loadSearch = () => {
+    if (searchBlogFn !== null) return Promise.resolve();
+    if (searchLoadPromise !== null) return searchLoadPromise;
+
+    isSearchLoading = true;
+    searchLoadPromise = import('$lib/posts/search')
+      .then(({ searchBlog }) => {
+        searchBlogFn = searchBlog;
+      })
+      .finally(() => {
+        isSearchLoading = false;
+        searchLoadPromise = null;
+      });
+
+    return searchLoadPromise;
+  };
 
   const openSearch = async ({
     restoreFocusTarget = null,
@@ -52,6 +95,7 @@
       focusRestoreTarget = restoreFocusTarget;
       isSearchOpen = true;
     }
+    void loadSearch();
 
     await tick();
     searchInput?.focus();
@@ -62,12 +106,7 @@
     isSearchOpen = false;
     await tick();
 
-    if (
-      restoreFocus &&
-      focusRestoreTarget &&
-      focusRestoreTarget !== searchTrigger &&
-      focusRestoreTarget !== document.body
-    ) {
+    if (restoreFocus && focusRestoreTarget && focusRestoreTarget !== document.body) {
       focusRestoreTarget.focus();
     }
 
@@ -124,30 +163,23 @@
     {/if}
   </div>
 
-  <div class="search-field">
-    <label class="search-label" for="post-search-trigger">記事を検索</label>
-    <div class="search-trigger-wrapper">
-      <input
-        bind:this={searchTrigger}
-        id="post-search-trigger"
-        class="search-trigger"
-        type="text"
-        value=""
-        placeholder="タイトル・本文・タグから検索"
-        readonly
-        aria-haspopup="dialog"
-        onfocus={() => openSearch()}
-        onclick={() => openSearch()}
+  <button
+    bind:this={searchTrigger}
+    type="button"
+    class="search-trigger"
+    aria-label="記事を検索"
+    aria-haspopup="dialog"
+    aria-expanded={isSearchOpen}
+    aria-controls="blog-search-dialog"
+    aria-keyshortcuts="Control+K Meta+K"
+    onclick={(event) => openSearch({ restoreFocusTarget: event.currentTarget })}
+  >
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        d="M10.8 5.2a5.6 5.6 0 1 0 0 11.2 5.6 5.6 0 0 0 0-11.2Zm-7.2 5.6a7.2 7.2 0 1 1 12.7 4.6l4 4a.8.8 0 0 1-1.1 1.1l-4-4A7.2 7.2 0 0 1 3.6 10.8Z"
       />
-      <span class="shortcut-hint" aria-hidden="true">
-        <kbd>Ctrl</kbd>
-        <span>+</span>
-        <kbd>K</kbd>
-        <span class="mac-shortcut">/ ⌘K</span>
-      </span>
-    </div>
-    <p class="search-note">タイトル・本文・タグ・作曲家・演奏会から検索できます。</p>
-  </div>
+    </svg>
+  </button>
 </section>
 
 {#if isSearchOpen}
@@ -158,14 +190,17 @@
       tabindex="-1"
       aria-label="検索を閉じる"
       onclick={() => closeSearch({ restoreFocus: true })}
+      transition:fade={{ duration: 140 }}
     ></button>
     <div
       bind:this={searchDialog}
+      id="blog-search-dialog"
       class="search-dialog"
       role="dialog"
       tabindex="-1"
       aria-modal="true"
       aria-labelledby="blog-search-heading"
+      transition:fly={{ y: -12, duration: 160 }}
       onkeydown={(event) => {
         if (event.key === 'Escape') {
           event.preventDefault();
@@ -191,21 +226,19 @@
       <div class="search-dialog-header">
         <div class="search-dialog-title-group">
           <p id="blog-search-heading" class="search-dialog-title">ブログを検索</p>
-          <p class="search-dialog-note">
-            {#if tag}
-              現在は #&thinsp;{tag} の一覧を表示中です。検索対象は全記事です。
-            {:else}
-              検索対象は全記事です。
-            {/if}
-          </p>
         </div>
 
         <button
           type="button"
           class="close-button"
+          aria-label="検索を閉じる"
           onclick={() => closeSearch({ restoreFocus: true })}
         >
-          閉じる
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M6.2 5.1 12 10.9l5.8-5.8a.8.8 0 0 1 1.1 1.1L13.1 12l5.8 5.8a.8.8 0 0 1-1.1 1.1L12 13.1l-5.8 5.8a.8.8 0 1 1-1.1-1.1l5.8-5.8-5.8-5.8a.8.8 0 1 1 1.1-1.1Z"
+            />
+          </svg>
         </button>
       </div>
 
@@ -221,118 +254,120 @@
           autocomplete="off"
           autocapitalize="off"
           spellcheck="false"
+          aria-keyshortcuts="Control+K Meta+K"
         />
+        <span class="input-shortcut-hint" aria-hidden="true">
+          <kbd>Ctrl</kbd>
+          <span>+</span>
+          <kbd>K</kbd>
+          <span class="mac-shortcut">/ ⌘K</span>
+        </span>
       </div>
+      <p class="sr-only" role="status" aria-live="polite">{resultStatusText}</p>
 
-      <div class="search-results">
-        {#if searchQuery.trim().length === 0}
-          <div class="search-empty-state">
-            <p>タイトル・本文・タグ・作曲家・演奏会を横断検索できます。</p>
-            <p class="keyboard-help">
-              <kbd>Esc</kbd> で閉じます。<span class="divider">/</span><kbd>Ctrl</kbd>+<kbd>K</kbd>
-              で再度開けます。
-            </p>
-          </div>
-        {:else if hasAnyResults}
-          <div class="search-sections">
-            {#if searchResults.articles.length > 0}
-              <section class="result-section">
-                <h3>記事</h3>
-                <ul class="result-list article-result-list">
-                  {#each searchResults.articles as article (article.slug)}
-                    <li>
-                      <a
-                        href={resolve('/post/[slug]', { slug: article.slug })}
-                        class="article-result"
-                        onclick={() => closeSearch()}
-                      >
-                        <div class="article-result-meta">
-                          <span class="match-label">{article.matchedFieldLabel}</span>
-                          <span class="published-at">
-                            {formatDate2JpStyle(article.publishedAt)}
-                          </span>
-                        </div>
-                        <strong>{article.title}</strong>
-                        <p>{article.description}……</p>
-                        <div class="article-result-tags">
-                          {#each article.tags as articleTag (articleTag)}
-                            <span class="article-result-tag">#&thinsp;{articleTag}</span>
-                          {/each}
-                        </div>
-                      </a>
-                    </li>
-                  {/each}
-                </ul>
-              </section>
-            {/if}
+      {#if trimmedSearchQuery.length > 0 && searchBlogFn !== null}
+        <div class="search-results">
+          {#if hasAnyResults}
+            <div class="search-sections">
+              {#if searchResults.articles.length > 0}
+                <section class="result-section">
+                  <h3>記事</h3>
+                  <ul class="result-list article-result-list">
+                    {#each searchResults.articles as article (article.slug)}
+                      <li>
+                        <a
+                          href={resolve('/post/[slug]', { slug: article.slug })}
+                          class="article-result"
+                          onclick={() => closeSearch()}
+                        >
+                          <div class="article-result-meta">
+                            <span class="match-label">{article.matchedFieldLabel}</span>
+                            <span class="published-at">
+                              {formatDate2JpStyle(article.publishedAt)}
+                            </span>
+                          </div>
+                          <strong>{article.title}</strong>
+                          <p>{article.description}……</p>
+                          <div class="article-result-tags">
+                            {#each article.tags as articleTag (articleTag)}
+                              <span class="article-result-tag">#&thinsp;{articleTag}</span>
+                            {/each}
+                          </div>
+                        </a>
+                      </li>
+                    {/each}
+                  </ul>
+                </section>
+              {/if}
 
-            {#if searchResults.composers.length > 0}
-              <section class="result-section">
-                <h3>作曲家</h3>
-                <ul class="result-list compact-result-list">
-                  {#each searchResults.composers as composer (composer.slug)}
-                    <li>
-                      <a
-                        href={resolve('/tag/[tag=tag]', { tag: composer.tag })}
-                        class="compact-result"
-                        onclick={() => closeSearch()}
-                      >
-                        <strong>{composer.shortName}</strong>
-                        <span>{composer.fullName}</span>
-                      </a>
-                    </li>
-                  {/each}
-                </ul>
-              </section>
-            {/if}
+              {#if searchResults.composers.length > 0}
+                <section class="result-section">
+                  <h3>作曲家</h3>
+                  <ul class="result-list compact-result-list">
+                    {#each searchResults.composers as composer (composer.slug)}
+                      <li>
+                        <a
+                          href={resolve('/tag/[tag=tag]', { tag: composer.tag })}
+                          class="compact-result"
+                          onclick={() => closeSearch()}
+                        >
+                          <strong>{composer.shortName}</strong>
+                          <span>{composer.fullName}</span>
+                        </a>
+                      </li>
+                    {/each}
+                  </ul>
+                </section>
+              {/if}
 
-            {#if searchResults.concerts.length > 0}
-              <section class="result-section">
-                <h3>演奏会</h3>
-                <ul class="result-list compact-result-list">
-                  {#each searchResults.concerts as concert (concert.slug)}
-                    <li>
-                      <a
-                        href={resolve('/tag/[tag=tag]', { tag: concert.tag })}
-                        class="compact-result"
-                        onclick={() => closeSearch()}
-                      >
-                        <strong>{concert.title}</strong>
-                        <span>{formatDate2JpStyle(concert.date)}</span>
-                      </a>
-                    </li>
-                  {/each}
-                </ul>
-              </section>
-            {/if}
+              {#if searchResults.concerts.length > 0}
+                <section class="result-section">
+                  <h3>演奏会</h3>
+                  <ul class="result-list compact-result-list">
+                    {#each searchResults.concerts as concert (concert.slug)}
+                      <li>
+                        <a
+                          href={resolve('/tag/[tag=tag]', { tag: concert.tag })}
+                          class="compact-result"
+                          onclick={() => closeSearch()}
+                        >
+                          <strong>{concert.title}</strong>
+                          <span>{formatDate2JpStyle(concert.date)}</span>
+                        </a>
+                      </li>
+                    {/each}
+                  </ul>
+                </section>
+              {/if}
 
-            {#if searchResults.tags.length > 0}
-              <section class="result-section">
-                <h3>タグ</h3>
-                <ul class="result-list compact-result-list">
-                  {#each searchResults.tags as entry (entry.tag)}
-                    <li>
-                      <a
-                        href={resolve('/tag/[tag=tag]', { tag: entry.tag })}
-                        class="compact-result"
-                        onclick={() => closeSearch()}
-                      >
-                        <strong>#&thinsp;{entry.tag}</strong>
-                        <span>タグページを開く</span>
-                      </a>
-                    </li>
-                  {/each}
-                </ul>
-              </section>
-            {/if}
-          </div>
-        {:else}
-          <div class="search-empty-state">
-            <p>「{searchQuery}」に一致する結果は見つかりませんでした。</p>
-            <p>キーワードを短くするか、作曲家名・演奏会名でもお試しください。</p>
-          </div>
-        {/if}
-      </div>
+              {#if searchResults.tags.length > 0}
+                <section class="result-section">
+                  <h3>タグ</h3>
+                  <ul class="result-list compact-result-list">
+                    {#each searchResults.tags as entry (entry.tag)}
+                      <li>
+                        <a
+                          href={resolve('/tag/[tag=tag]', { tag: entry.tag })}
+                          class="compact-result"
+                          onclick={() => closeSearch()}
+                        >
+                          <strong>#&thinsp;{entry.tag}</strong>
+                          <span>タグページを開く</span>
+                        </a>
+                      </li>
+                    {/each}
+                  </ul>
+                </section>
+              {/if}
+            </div>
+          {:else}
+            <div class="search-empty-state">
+              <p>「{searchQuery}」に一致する結果は見つかりませんでした。</p>
+              <p>キーワードを短くするか、作曲家名・演奏会名でもお試しください。</p>
+            </div>
+          {/if}
+        </div>
+      {/if}
     </div>
   </div>
 {/if}
@@ -342,11 +377,13 @@
 <style>
   .post-list-header {
     display: flex;
-    flex-direction: column;
+    justify-content: space-between;
     gap: calc(var(--spacing-unit) * 5);
+    align-items: flex-start;
   }
 
   .heading-group {
+    min-width: 0;
     display: flex;
     flex-direction: column;
     gap: calc(var(--spacing-unit) * 1);
@@ -363,71 +400,59 @@
     color: var(--color-text-secondary);
   }
 
-  .search-field {
-    display: flex;
-    flex-direction: column;
-    gap: calc(var(--spacing-unit) * 2);
-  }
-
-  .search-label {
-    font-size: 0.95em;
-    color: var(--color-text-secondary);
-  }
-
-  .search-trigger-wrapper {
-    position: relative;
-    display: flex;
+  .search-trigger {
+    flex: 0 0 auto;
+    display: inline-flex;
+    justify-content: center;
     align-items: center;
+    width: calc(var(--spacing-unit) * 11);
+    height: calc(var(--spacing-unit) * 11);
+    border: 1px solid var(--color-text-primary);
+    border-radius: calc(var(--spacing-unit) * 2);
+    padding: 0;
+    background-color: rgba(255, 255, 255, 0.92);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
   }
 
-  .search-trigger,
+  .search-trigger svg,
+  .close-button svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    fill: currentColor;
+  }
+
+  .search-trigger:hover,
+  .close-button:hover {
+    border-color: var(--color-text-primary);
+    background-color: rgba(238, 238, 238, 0.8);
+  }
+
+  .search-trigger:focus-visible,
+  .close-button:focus-visible {
+    outline: 2px solid var(--color-text-primary);
+    outline-offset: 2px;
+  }
+
   .search-input {
     box-sizing: border-box;
     width: 100%;
     border: 1px solid var(--color-text-primary);
     border-radius: calc(var(--spacing-unit) * 2);
-    padding: calc(var(--spacing-unit) * 4) calc(var(--spacing-unit) * 5);
+    padding: calc(var(--spacing-unit) * 4) calc(var(--spacing-unit) * 34)
+      calc(var(--spacing-unit) * 4) calc(var(--spacing-unit) * 5);
     font: inherit;
+    font-size: 1.05rem;
     background-color: rgba(255, 255, 255, 0.92);
     color: inherit;
   }
 
-  .search-trigger {
-    cursor: text;
-    padding-right: calc(var(--spacing-unit) * 34);
-  }
-
-  .search-trigger::placeholder,
   .search-input::placeholder {
     color: var(--color-text-secondary);
     opacity: 1;
-  }
-
-  .search-note {
-    margin: 0;
-    font-size: 0.9em;
-    color: var(--color-text-secondary);
-  }
-
-  .shortcut-hint {
-    position: absolute;
-    right: calc(var(--spacing-unit) * 4);
-    display: inline-flex;
-    align-items: center;
-    gap: calc(var(--spacing-unit) * 1);
-    font-size: 0.78em;
-    color: var(--color-text-secondary);
-    pointer-events: none;
-  }
-
-  .shortcut-hint kbd,
-  .keyboard-help kbd {
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    border-radius: calc(var(--spacing-unit) * 1.5);
-    padding: 0 calc(var(--spacing-unit) * 1.5);
-    font-family: inherit;
-    font-size: 0.95em;
-    background-color: rgba(255, 255, 255, 0.75);
   }
 
   .search-layer {
@@ -469,7 +494,7 @@
     display: flex;
     justify-content: space-between;
     gap: calc(var(--spacing-unit) * 4);
-    align-items: flex-start;
+    align-items: center;
   }
 
   .search-dialog-title-group {
@@ -478,36 +503,54 @@
     gap: calc(var(--spacing-unit) * 1);
   }
 
-  .search-dialog-title,
-  .search-dialog-note {
-    margin: 0;
-  }
-
   .search-dialog-title {
     font-family: var(--serif);
     font-size: 1.25rem;
-  }
-
-  .search-dialog-note {
-    color: var(--color-text-secondary);
-    font-size: 0.9em;
+    margin: 0;
   }
 
   .close-button {
+    flex: 0 0 auto;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: calc(var(--spacing-unit) * 10);
+    height: calc(var(--spacing-unit) * 10);
     border: 1px solid var(--color-text-primary);
     border-radius: calc(var(--spacing-unit) * 2);
-    padding: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 4);
-    font: inherit;
+    padding: 0;
     background: transparent;
+    color: inherit;
     cursor: pointer;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
   }
 
   .search-input-wrapper {
+    position: relative;
     display: flex;
+    align-items: center;
   }
 
-  .search-input {
-    font-size: 1.05rem;
+  .input-shortcut-hint {
+    position: absolute;
+    right: calc(var(--spacing-unit) * 4);
+    display: inline-flex;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 1);
+    font-size: 0.78em;
+    color: var(--color-text-secondary);
+    pointer-events: none;
+  }
+
+  .input-shortcut-hint kbd {
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-radius: calc(var(--spacing-unit) * 1.5);
+    padding: 0 calc(var(--spacing-unit) * 1.5);
+    font-family: inherit;
+    font-size: 0.95em;
+    background-color: rgba(255, 255, 255, 0.75);
   }
 
   .search-results {
@@ -550,8 +593,7 @@
   }
 
   .article-result:hover,
-  .compact-result:hover,
-  .close-button:hover {
+  .compact-result:hover {
     border-color: var(--color-text-primary);
     background-color: rgba(238, 238, 238, 0.8);
     text-decoration: none;
@@ -617,17 +659,6 @@
     margin: 0;
   }
 
-  .keyboard-help {
-    display: flex;
-    align-items: center;
-    gap: calc(var(--spacing-unit) * 1.5);
-    flex-wrap: wrap;
-  }
-
-  .divider {
-    color: rgba(0, 0, 0, 0.3);
-  }
-
   .sr-only {
     position: absolute;
     width: 1px;
@@ -641,23 +672,13 @@
   }
 
   @media (max-width: 576px) {
+    .post-list-header {
+      flex-direction: column;
+      gap: calc(var(--spacing-unit) * 3);
+    }
+
     h2 {
       font-size: 1.7rem;
-    }
-
-    .search-trigger {
-      padding-right: calc(var(--spacing-unit) * 5);
-    }
-
-    .shortcut-hint {
-      position: static;
-      justify-content: flex-end;
-      margin-top: calc(var(--spacing-unit) * 2);
-    }
-
-    .search-trigger-wrapper {
-      flex-direction: column;
-      align-items: stretch;
     }
 
     .search-layer {
@@ -671,11 +692,19 @@
     }
 
     .search-dialog-header {
-      flex-direction: column;
+      gap: calc(var(--spacing-unit) * 3);
     }
 
     .close-button {
       align-self: flex-end;
+    }
+
+    .search-input {
+      padding-right: calc(var(--spacing-unit) * 20);
+    }
+
+    .input-shortcut-hint .mac-shortcut {
+      display: none;
     }
 
     .article-result-meta {

--- a/src/lib/component/SearchablePostList.svelte
+++ b/src/lib/component/SearchablePostList.svelte
@@ -1,0 +1,687 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { resolve } from '$app/paths';
+  import { onMount, tick } from 'svelte';
+  import type { Post } from '$lib/posts';
+  import { searchBlog } from '$lib/posts/search';
+  import type { Tag } from '$lib/posts/tags';
+  import { formatDate2JpStyle } from '$lib/util';
+  import PostList from './PostList.svelte';
+
+  interface Props {
+    heading: string;
+    summary?: string;
+    posts: Post[];
+    tag?: Tag;
+    currentPageNumber: number;
+    totalNumberOfPages: number;
+  }
+
+  let {
+    heading,
+    summary = undefined,
+    posts,
+    tag = undefined,
+    currentPageNumber,
+    totalNumberOfPages
+  }: Props = $props();
+
+  let isSearchOpen = $state(false);
+  let searchQuery = $state('');
+  let searchTrigger = $state<HTMLInputElement | null>(null);
+  let searchInput = $state<HTMLInputElement | null>(null);
+  let searchDialog = $state<HTMLDivElement | null>(null);
+  let focusRestoreTarget: HTMLElement | null = null;
+
+  const searchResults = $derived(searchBlog(searchQuery));
+  const hasAnyResults = $derived(
+    searchResults.articles.length > 0 ||
+      searchResults.tags.length > 0 ||
+      searchResults.composers.length > 0 ||
+      searchResults.concerts.length > 0
+  );
+
+  const openSearch = async ({
+    restoreFocusTarget = null,
+    selectQuery = true
+  }: {
+    restoreFocusTarget?: HTMLElement | null;
+    selectQuery?: boolean;
+  } = {}) => {
+    if (!isSearchOpen) {
+      focusRestoreTarget = restoreFocusTarget;
+      isSearchOpen = true;
+    }
+
+    await tick();
+    searchInput?.focus();
+    if (selectQuery) searchInput?.select();
+  };
+
+  const closeSearch = async ({ restoreFocus = false }: { restoreFocus?: boolean } = {}) => {
+    isSearchOpen = false;
+    await tick();
+
+    if (
+      restoreFocus &&
+      focusRestoreTarget &&
+      focusRestoreTarget !== searchTrigger &&
+      focusRestoreTarget !== document.body
+    ) {
+      focusRestoreTarget.focus();
+    }
+
+    focusRestoreTarget = null;
+  };
+
+  const getFocusableElements = () => {
+    if (searchDialog === null) return [];
+
+    return [
+      ...searchDialog.querySelectorAll<HTMLElement>('a[href], button, input, [tabindex]')
+    ].filter((element) => {
+      const tabindex = element.getAttribute('tabindex');
+      return !element.hasAttribute('disabled') && tabindex !== '-1';
+    });
+  };
+
+  onMount(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.isComposing) return;
+      if (event.altKey || event.shiftKey) return;
+      if (!event.ctrlKey && !event.metaKey) return;
+      if (event.key.toLowerCase() !== 'k') return;
+
+      event.preventDefault();
+      const activeElement =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      openSearch({
+        restoreFocusTarget: activeElement
+      });
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+    };
+  });
+
+  $effect(() => {
+    if (!browser) return;
+
+    document.body.style.overflow = isSearchOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  });
+</script>
+
+<section class="post-list-header">
+  <div class="heading-group">
+    <h2>{heading}</h2>
+    {#if summary}
+      <p class="summary">{summary}</p>
+    {/if}
+  </div>
+
+  <div class="search-field">
+    <label class="search-label" for="post-search-trigger">記事を検索</label>
+    <div class="search-trigger-wrapper">
+      <input
+        bind:this={searchTrigger}
+        id="post-search-trigger"
+        class="search-trigger"
+        type="text"
+        value=""
+        placeholder="タイトル・本文・タグから検索"
+        readonly
+        aria-haspopup="dialog"
+        onfocus={() => openSearch()}
+        onclick={() => openSearch()}
+      />
+      <span class="shortcut-hint" aria-hidden="true">
+        <kbd>Ctrl</kbd>
+        <span>+</span>
+        <kbd>K</kbd>
+        <span class="mac-shortcut">/ ⌘K</span>
+      </span>
+    </div>
+    <p class="search-note">タイトル・本文・タグ・作曲家・演奏会から検索できます。</p>
+  </div>
+</section>
+
+{#if isSearchOpen}
+  <div class="search-layer" role="presentation">
+    <button
+      type="button"
+      class="search-backdrop"
+      tabindex="-1"
+      aria-label="検索を閉じる"
+      onclick={() => closeSearch({ restoreFocus: true })}
+    ></button>
+    <div
+      bind:this={searchDialog}
+      class="search-dialog"
+      role="dialog"
+      tabindex="-1"
+      aria-modal="true"
+      aria-labelledby="blog-search-heading"
+      onkeydown={(event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeSearch({ restoreFocus: true });
+        }
+        if (event.key === 'Tab') {
+          const focusableElements = getFocusableElements();
+          if (focusableElements.length === 0) return;
+
+          const firstElement = focusableElements[0];
+          const lastElement = focusableElements[focusableElements.length - 1];
+
+          if (event.shiftKey && document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement.focus();
+          } else if (!event.shiftKey && document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }}
+    >
+      <div class="search-dialog-header">
+        <div class="search-dialog-title-group">
+          <p id="blog-search-heading" class="search-dialog-title">ブログを検索</p>
+          <p class="search-dialog-note">
+            {#if tag}
+              現在は #&thinsp;{tag} の一覧を表示中です。検索対象は全記事です。
+            {:else}
+              検索対象は全記事です。
+            {/if}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          class="close-button"
+          onclick={() => closeSearch({ restoreFocus: true })}
+        >
+          閉じる
+        </button>
+      </div>
+
+      <div class="search-input-wrapper">
+        <label class="sr-only" for="blog-search-input">ブログを検索</label>
+        <input
+          bind:this={searchInput}
+          id="blog-search-input"
+          class="search-input"
+          type="text"
+          bind:value={searchQuery}
+          placeholder="タイトル・本文・タグ・作曲家・演奏会から検索"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+        />
+      </div>
+
+      <div class="search-results">
+        {#if searchQuery.trim().length === 0}
+          <div class="search-empty-state">
+            <p>タイトル・本文・タグ・作曲家・演奏会を横断検索できます。</p>
+            <p class="keyboard-help">
+              <kbd>Esc</kbd> で閉じます。<span class="divider">/</span><kbd>Ctrl</kbd>+<kbd>K</kbd>
+              で再度開けます。
+            </p>
+          </div>
+        {:else if hasAnyResults}
+          <div class="search-sections">
+            {#if searchResults.articles.length > 0}
+              <section class="result-section">
+                <h3>記事</h3>
+                <ul class="result-list article-result-list">
+                  {#each searchResults.articles as article (article.slug)}
+                    <li>
+                      <a
+                        href={resolve('/post/[slug]', { slug: article.slug })}
+                        class="article-result"
+                        onclick={() => closeSearch()}
+                      >
+                        <div class="article-result-meta">
+                          <span class="match-label">{article.matchedFieldLabel}</span>
+                          <span class="published-at">
+                            {formatDate2JpStyle(article.publishedAt)}
+                          </span>
+                        </div>
+                        <strong>{article.title}</strong>
+                        <p>{article.description}……</p>
+                        <div class="article-result-tags">
+                          {#each article.tags as articleTag (articleTag)}
+                            <span class="article-result-tag">#&thinsp;{articleTag}</span>
+                          {/each}
+                        </div>
+                      </a>
+                    </li>
+                  {/each}
+                </ul>
+              </section>
+            {/if}
+
+            {#if searchResults.composers.length > 0}
+              <section class="result-section">
+                <h3>作曲家</h3>
+                <ul class="result-list compact-result-list">
+                  {#each searchResults.composers as composer (composer.slug)}
+                    <li>
+                      <a
+                        href={resolve('/tag/[tag=tag]', { tag: composer.tag })}
+                        class="compact-result"
+                        onclick={() => closeSearch()}
+                      >
+                        <strong>{composer.shortName}</strong>
+                        <span>{composer.fullName}</span>
+                      </a>
+                    </li>
+                  {/each}
+                </ul>
+              </section>
+            {/if}
+
+            {#if searchResults.concerts.length > 0}
+              <section class="result-section">
+                <h3>演奏会</h3>
+                <ul class="result-list compact-result-list">
+                  {#each searchResults.concerts as concert (concert.slug)}
+                    <li>
+                      <a
+                        href={resolve('/tag/[tag=tag]', { tag: concert.tag })}
+                        class="compact-result"
+                        onclick={() => closeSearch()}
+                      >
+                        <strong>{concert.title}</strong>
+                        <span>{formatDate2JpStyle(concert.date)}</span>
+                      </a>
+                    </li>
+                  {/each}
+                </ul>
+              </section>
+            {/if}
+
+            {#if searchResults.tags.length > 0}
+              <section class="result-section">
+                <h3>タグ</h3>
+                <ul class="result-list compact-result-list">
+                  {#each searchResults.tags as entry (entry.tag)}
+                    <li>
+                      <a
+                        href={resolve('/tag/[tag=tag]', { tag: entry.tag })}
+                        class="compact-result"
+                        onclick={() => closeSearch()}
+                      >
+                        <strong>#&thinsp;{entry.tag}</strong>
+                        <span>タグページを開く</span>
+                      </a>
+                    </li>
+                  {/each}
+                </ul>
+              </section>
+            {/if}
+          </div>
+        {:else}
+          <div class="search-empty-state">
+            <p>「{searchQuery}」に一致する結果は見つかりませんでした。</p>
+            <p>キーワードを短くするか、作曲家名・演奏会名でもお試しください。</p>
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<PostList {posts} {tag} {currentPageNumber} {totalNumberOfPages} />
+
+<style>
+  .post-list-header {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 5);
+  }
+
+  .heading-group {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 1);
+  }
+
+  h2 {
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 2rem;
+  }
+
+  .summary {
+    margin: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .search-field {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 2);
+  }
+
+  .search-label {
+    font-size: 0.95em;
+    color: var(--color-text-secondary);
+  }
+
+  .search-trigger-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .search-trigger,
+  .search-input {
+    box-sizing: border-box;
+    width: 100%;
+    border: 1px solid var(--color-text-primary);
+    border-radius: calc(var(--spacing-unit) * 2);
+    padding: calc(var(--spacing-unit) * 4) calc(var(--spacing-unit) * 5);
+    font: inherit;
+    background-color: rgba(255, 255, 255, 0.92);
+    color: inherit;
+  }
+
+  .search-trigger {
+    cursor: text;
+    padding-right: calc(var(--spacing-unit) * 34);
+  }
+
+  .search-trigger::placeholder,
+  .search-input::placeholder {
+    color: var(--color-text-secondary);
+    opacity: 1;
+  }
+
+  .search-note {
+    margin: 0;
+    font-size: 0.9em;
+    color: var(--color-text-secondary);
+  }
+
+  .shortcut-hint {
+    position: absolute;
+    right: calc(var(--spacing-unit) * 4);
+    display: inline-flex;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 1);
+    font-size: 0.78em;
+    color: var(--color-text-secondary);
+    pointer-events: none;
+  }
+
+  .shortcut-hint kbd,
+  .keyboard-help kbd {
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-radius: calc(var(--spacing-unit) * 1.5);
+    padding: 0 calc(var(--spacing-unit) * 1.5);
+    font-family: inherit;
+    font-size: 0.95em;
+    background-color: rgba(255, 255, 255, 0.75);
+  }
+
+  .search-layer {
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+    display: grid;
+    place-items: start center;
+    overflow-y: auto;
+    padding: calc(var(--spacing-unit) * 8);
+  }
+
+  .search-backdrop {
+    position: fixed;
+    inset: 0;
+    border: 0;
+    padding: 0;
+    background: rgba(238, 238, 238, 0.7);
+    backdrop-filter: blur(6px);
+  }
+
+  .search-dialog {
+    position: relative;
+    z-index: 1;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 4);
+    width: min(100%, 760px);
+    max-height: min(80vh, 760px);
+    border: 1px solid var(--color-text-primary);
+    border-radius: calc(var(--spacing-unit) * 3);
+    padding: calc(var(--spacing-unit) * 6);
+    background-color: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.16);
+  }
+
+  .search-dialog-header {
+    display: flex;
+    justify-content: space-between;
+    gap: calc(var(--spacing-unit) * 4);
+    align-items: flex-start;
+  }
+
+  .search-dialog-title-group {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 1);
+  }
+
+  .search-dialog-title,
+  .search-dialog-note {
+    margin: 0;
+  }
+
+  .search-dialog-title {
+    font-family: var(--serif);
+    font-size: 1.25rem;
+  }
+
+  .search-dialog-note {
+    color: var(--color-text-secondary);
+    font-size: 0.9em;
+  }
+
+  .close-button {
+    border: 1px solid var(--color-text-primary);
+    border-radius: calc(var(--spacing-unit) * 2);
+    padding: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 4);
+    font: inherit;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .search-input-wrapper {
+    display: flex;
+  }
+
+  .search-input {
+    font-size: 1.05rem;
+  }
+
+  .search-results {
+    overflow-y: auto;
+  }
+
+  .search-sections {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 6);
+  }
+
+  .result-section h3 {
+    margin-top: 0;
+    margin-bottom: calc(var(--spacing-unit) * 3);
+    font-size: 1rem;
+    color: var(--color-text-secondary);
+  }
+
+  .result-list {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 3);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .article-result,
+  .compact-result {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 2);
+    border: 1px solid rgba(0, 0, 0, 0.14);
+    border-radius: calc(var(--spacing-unit) * 2);
+    padding: calc(var(--spacing-unit) * 4);
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
+  }
+
+  .article-result:hover,
+  .compact-result:hover,
+  .close-button:hover {
+    border-color: var(--color-text-primary);
+    background-color: rgba(238, 238, 238, 0.8);
+    text-decoration: none;
+  }
+
+  .article-result strong,
+  .compact-result strong {
+    font-family: var(--serif);
+  }
+
+  .article-result p,
+  .compact-result span,
+  .published-at {
+    margin: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .article-result-meta {
+    display: flex;
+    justify-content: space-between;
+    gap: calc(var(--spacing-unit) * 4);
+    align-items: center;
+    font-size: 0.85em;
+  }
+
+  .match-label {
+    display: inline-block;
+    border: 1px solid rgba(0, 0, 0, 0.18);
+    border-radius: 999px;
+    padding: 0 calc(var(--spacing-unit) * 2);
+    color: var(--color-text-secondary);
+  }
+
+  .article-result p {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+
+  .article-result-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 3);
+    font-size: 0.86em;
+    color: var(--color-text-secondary);
+  }
+
+  .article-result-tag {
+    white-space: nowrap;
+  }
+
+  .search-empty-state {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 2);
+    padding: calc(var(--spacing-unit) * 4) 0;
+    color: var(--color-text-secondary);
+  }
+
+  .search-empty-state p {
+    margin: 0;
+  }
+
+  .keyboard-help {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 1.5);
+    flex-wrap: wrap;
+  }
+
+  .divider {
+    color: rgba(0, 0, 0, 0.3);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 576px) {
+    h2 {
+      font-size: 1.7rem;
+    }
+
+    .search-trigger {
+      padding-right: calc(var(--spacing-unit) * 5);
+    }
+
+    .shortcut-hint {
+      position: static;
+      justify-content: flex-end;
+      margin-top: calc(var(--spacing-unit) * 2);
+    }
+
+    .search-trigger-wrapper {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .search-layer {
+      padding: calc(var(--spacing-unit) * 4);
+    }
+
+    .search-dialog {
+      min-height: calc(100vh - var(--spacing-unit) * 8);
+      max-height: calc(100vh - var(--spacing-unit) * 8);
+      padding: calc(var(--spacing-unit) * 5);
+    }
+
+    .search-dialog-header {
+      flex-direction: column;
+    }
+
+    .close-button {
+      align-self: flex-end;
+    }
+
+    .article-result-meta {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: calc(var(--spacing-unit) * 1);
+    }
+  }
+</style>

--- a/src/lib/component/SearchablePostList.svelte
+++ b/src/lib/component/SearchablePostList.svelte
@@ -6,7 +6,7 @@
   import { onMount, tick } from 'svelte';
   import { fade, fly } from 'svelte/transition';
   import type { Page } from '@sveltejs/kit';
-  import type { Post } from '$lib/posts';
+  import type { PostListItem } from '$lib/posts';
   import type { BlogSearchResults } from '$lib/posts/search';
   import type { Tag } from '$lib/posts/tags';
   import { formatDate2JpStyle } from '$lib/util';
@@ -15,7 +15,7 @@
   interface Props {
     heading: string;
     summary?: string;
-    posts: Post[];
+    posts: PostListItem[];
     tag?: Tag;
     currentPageNumber: number;
     totalNumberOfPages: number;
@@ -82,7 +82,8 @@
 
     isSearchLoading = true;
     searchLoadPromise = import('$lib/posts/search')
-      .then(({ searchBlog }) => {
+      .then(async ({ loadBlogSearchIndex, searchBlog }) => {
+        await loadBlogSearchIndex();
         searchBlogFn = searchBlog;
       })
       .finally(() => {
@@ -327,9 +328,13 @@
       </div>
       <p class="sr-only" role="status" aria-live="polite">{resultStatusText}</p>
 
-      {#if trimmedSearchQuery.length > 0 && searchBlogFn !== null}
+      {#if trimmedSearchQuery.length > 0}
         <div class="search-results">
-          {#if hasAnyResults}
+          {#if isSearchLoading && searchBlogFn === null}
+            <div class="search-empty-state">
+              <p>検索を読み込んでいます。</p>
+            </div>
+          {:else if hasAnyResults}
             <div class="search-sections">
               {#if searchResults.articles.length > 0}
                 <section class="result-section">

--- a/src/lib/posts/index.ts
+++ b/src/lib/posts/index.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'svelte';
-import { convertToDescription, convertToPlainText } from '$lib/util';
+import { convertToDescription } from '$lib/util';
 import { composers, type composerSlug } from './composers';
 import type { concertSlug } from './concerts';
 import type { Tag } from './tags';
@@ -15,51 +15,61 @@ export type Metadata = {
   youTubeVideoIds?: string[];
   tags: Tag[];
 };
+
+export type PostMetadata = {
+  metadata: Metadata;
+  slug: string;
+};
+
+export type PostListItem = PostMetadata & {
+  description: string;
+};
+
 /** ポストオブジェクトの型 */
-export type Post = {
+export type Post = PostListItem & {
+  default: Component;
+};
+
+export type SearchablePost = PostListItem & {
+  searchText: string;
+};
+
+type PostModule = {
+  metadata: Metadata;
+  default: Component;
+};
+
+type InternalPost = {
   metadata: Metadata;
   slug: string;
   default: Component;
-  description: string;
-};
-export type SearchablePost = {
-  metadata: Metadata;
-  slug: string;
-  description: string;
-  searchText: string;
-};
-type InternalPost = Post & {
-  searchText: string;
+  loadRawPost: () => Promise<string>;
+  rawPost?: string;
+  description?: string;
 };
 
 // 動的に記事のSvelteファイルを取得する
-const modules = import.meta.glob('./**/post.svelte', { eager: true }) as Record<string, Post>;
+const modules = import.meta.glob('./**/post.svelte', { eager: true }) as Record<string, PostModule>;
 const rawModules = import.meta.glob('./**/post.svelte', {
   import: 'default',
-  query: '?raw',
-  eager: true
-}) as Record<string, string>;
+  query: '?raw'
+}) as Record<string, () => Promise<string>>;
+
 const posts: { [slug: string]: InternalPost } = {};
 Object.keys(modules).forEach((path) => {
   const slug = /^.+\/(?<slug>[^/]+)\/post\.svelte$/.exec(path)?.groups?.slug;
-  if (slug === undefined) return;
+  const loadRawPost = rawModules[path];
+  if (slug === undefined || loadRawPost === undefined) return;
 
-  const searchText = convertToPlainText(rawModules[path]);
   posts[slug] = {
     metadata: modules[path].metadata,
     slug: slug,
     default: modules[path].default,
-    description: convertToDescription(rawModules[path]),
-    searchText
+    loadRawPost
   };
 });
 
-/**
- * ポストを取得する
- * @param filterTag あるタグに一致する記事のみ抽出する場合指定
- * @returns ポストの配列
- */
-export const getPosts = (filterTag: Tag | undefined = undefined): Post[] =>
+const getSortedPublishedInternalPosts = (filterTag: Tag | undefined = undefined): InternalPost[] =>
   Object.keys(posts)
     .map((key) => posts[key])
     .filter((post) => post.metadata.published)
@@ -76,41 +86,89 @@ export const getPosts = (filterTag: Tag | undefined = undefined): Post[] =>
         new Date(postA.metadata.publicatedAt).getTime()
     );
 
+const getRawPost = async (post: InternalPost): Promise<string> => {
+  if (post.rawPost === undefined) {
+    post.rawPost = await post.loadRawPost();
+  }
+  return post.rawPost;
+};
+
+const getPostDescription = async (post: InternalPost): Promise<string> => {
+  if (post.description === undefined) {
+    post.description = convertToDescription(await getRawPost(post));
+  }
+  return post.description;
+};
+
+const toPostMetadata = (post: InternalPost): PostMetadata => ({
+  metadata: post.metadata,
+  slug: post.slug
+});
+
+const toPostListItem = async (post: InternalPost): Promise<PostListItem> => ({
+  ...toPostMetadata(post),
+  description: await getPostDescription(post)
+});
+
+const toPost = async (post: InternalPost): Promise<Post> => ({
+  ...(await toPostListItem(post)),
+  default: post.default
+});
+
 /**
- * 検索に利用する軽量なポスト情報を取得する
+ * ポストを取得する
  * @param filterTag あるタグに一致する記事のみ抽出する場合指定
- * @returns 検索用ポストの配列
+ * @returns ポストの配列
  */
-export const getSearchablePosts = (filterTag: Tag | undefined = undefined): SearchablePost[] =>
-  Object.keys(posts)
-    .map((key) => posts[key])
-    .filter((post) => post.metadata.published)
-    .filter((post) => {
-      if (filterTag === undefined) {
-        return true;
-      } else {
-        return post.metadata.tags.includes(filterTag);
-      }
-    })
-    .sort(
-      (postA, postB) =>
-        new Date(postB.metadata.publicatedAt).getTime() -
-        new Date(postA.metadata.publicatedAt).getTime()
-    )
-    .map((post) => ({
-      metadata: post.metadata,
-      slug: post.slug,
-      description: post.description,
-      searchText: post.searchText
-    }));
+export const getPosts = async (filterTag: Tag | undefined = undefined): Promise<Post[]> =>
+  Promise.all(getSortedPublishedInternalPosts(filterTag).map((post) => toPost(post)));
+
+/**
+ * 公開済みポスト数を取得する
+ * @param filterTag あるタグに一致する記事のみ抽出する場合指定
+ * @returns 公開済みポスト数
+ */
+export const getPostCount = (filterTag: Tag | undefined = undefined): number =>
+  getSortedPublishedInternalPosts(filterTag).length;
+
+/**
+ * 公開済みポストのメタ情報を取得する
+ * @param filterTag あるタグに一致する記事のみ抽出する場合指定
+ * @returns 公開済みポストのメタ情報の配列
+ */
+export const getPublishedPostMetadata = (filterTag: Tag | undefined = undefined): PostMetadata[] =>
+  getSortedPublishedInternalPosts(filterTag).map((post) => toPostMetadata(post));
+
+/**
+ * 表示に利用する軽量なポスト情報をページ単位で取得する
+ * @param filterTag あるタグに一致する記事のみ抽出する場合指定
+ * @param offset 取得開始位置
+ * @param limit 取得件数
+ * @returns 表示用ポストの配列
+ */
+export const getPostListItems = async ({
+  filterTag = undefined,
+  offset = 0,
+  limit
+}: {
+  filterTag?: Tag;
+  offset?: number;
+  limit?: number;
+} = {}): Promise<PostListItem[]> => {
+  const sortedPosts = getSortedPublishedInternalPosts(filterTag);
+  const selectedPosts =
+    limit === undefined ? sortedPosts.slice(offset) : sortedPosts.slice(offset, offset + limit);
+
+  return Promise.all(selectedPosts.map((post) => toPostListItem(post)));
+};
 
 /**
  * あるslugのポストを取得する
  * @param slug ポストのslug
  * @returns ポスト、該当がない場合は`null`
  */
-export const getPostBySlug = (slug: string): Post | null => {
-  if (Object.keys(posts).includes(slug)) return posts[slug];
+export const getPostBySlug = async (slug: string): Promise<Post | null> => {
+  if (Object.keys(posts).includes(slug)) return toPost(posts[slug]);
   return null;
 };
 
@@ -119,24 +177,29 @@ export const getPostBySlug = (slug: string): Post | null => {
  * @param slug 基準となるポストのslug
  * @returns 前後のポスト。該当がない場合は`null`
  */
-export const getAdjacentPostListItemsBySlug = (
+export const getAdjacentPostListItemsBySlug = async (
   slug: string
-): {
-  prev: Post | null;
-  next: Post | null;
-} => {
-  const post = getPostBySlug(slug);
-  if (post === null)
+): Promise<{
+  prev: PostListItem | null;
+  next: PostListItem | null;
+}> => {
+  if (!Object.keys(posts).includes(slug))
     return {
       prev: null,
       next: null
     };
 
-  const posts = getPosts();
-  const index = posts.findIndex((post) => post.slug === slug);
+  const sortedPosts = getSortedPublishedInternalPosts();
+  const index = sortedPosts.findIndex((post) => post.slug === slug);
+  if (index === -1)
+    return {
+      prev: null,
+      next: null
+    };
+
   return {
-    prev: index === posts.length - 1 ? null : posts[index + 1],
-    next: index === 0 ? null : posts[index - 1]
+    prev: index === sortedPosts.length - 1 ? null : await toPostListItem(sortedPosts[index + 1]),
+    next: index === 0 ? null : await toPostListItem(sortedPosts[index - 1])
   };
 };
 

--- a/src/lib/posts/index.ts
+++ b/src/lib/posts/index.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'svelte';
-import { convertToDescription } from '$lib/util';
+import { convertToDescription, convertToPlainText } from '$lib/util';
 import { composers, type composerSlug } from './composers';
 import type { concertSlug } from './concerts';
 import type { Tag } from './tags';
@@ -22,6 +22,15 @@ export type Post = {
   default: Component;
   description: string;
 };
+export type SearchablePost = {
+  metadata: Metadata;
+  slug: string;
+  description: string;
+  searchText: string;
+};
+type InternalPost = Post & {
+  searchText: string;
+};
 
 // 動的に記事のSvelteファイルを取得する
 const modules = import.meta.glob('./**/post.svelte', { eager: true }) as Record<string, Post>;
@@ -30,16 +39,18 @@ const rawModules = import.meta.glob('./**/post.svelte', {
   query: '?raw',
   eager: true
 }) as Record<string, string>;
-const posts: { [slug: string]: Post } = {};
+const posts: { [slug: string]: InternalPost } = {};
 Object.keys(modules).forEach((path) => {
   const slug = /^.+\/(?<slug>[^/]+)\/post\.svelte$/.exec(path)?.groups?.slug;
   if (slug === undefined) return;
 
+  const searchText = convertToPlainText(rawModules[path]);
   posts[slug] = {
     metadata: modules[path].metadata,
     slug: slug,
     default: modules[path].default,
-    description: convertToDescription(rawModules[path])
+    description: convertToDescription(rawModules[path]),
+    searchText
   };
 });
 
@@ -64,6 +75,34 @@ export const getPosts = (filterTag: Tag | undefined = undefined): Post[] =>
         new Date(postB.metadata.publicatedAt).getTime() -
         new Date(postA.metadata.publicatedAt).getTime()
     );
+
+/**
+ * 検索に利用する軽量なポスト情報を取得する
+ * @param filterTag あるタグに一致する記事のみ抽出する場合指定
+ * @returns 検索用ポストの配列
+ */
+export const getSearchablePosts = (filterTag: Tag | undefined = undefined): SearchablePost[] =>
+  Object.keys(posts)
+    .map((key) => posts[key])
+    .filter((post) => post.metadata.published)
+    .filter((post) => {
+      if (filterTag === undefined) {
+        return true;
+      } else {
+        return post.metadata.tags.includes(filterTag);
+      }
+    })
+    .sort(
+      (postA, postB) =>
+        new Date(postB.metadata.publicatedAt).getTime() -
+        new Date(postA.metadata.publicatedAt).getTime()
+    )
+    .map((post) => ({
+      metadata: post.metadata,
+      slug: post.slug,
+      description: post.description,
+      searchText: post.searchText
+    }));
 
 /**
  * あるslugのポストを取得する
@@ -115,7 +154,7 @@ export const getUrl = (slug: string): string => {
  * @param post
  * @returns タイトル文字列。e.g. `ラフマニノフ / 交響的舞曲`
  */
-export const getFullTitle = (post: Post): string => {
+export const getFullTitle = (post: Pick<Post, 'metadata'>): string => {
   if (post.metadata.composerSlug)
     return `${composers[post.metadata.composerSlug].shortName} / ${post.metadata.title}`;
   return post.metadata.title;

--- a/src/lib/posts/search.ts
+++ b/src/lib/posts/search.ts
@@ -78,8 +78,13 @@ type ConcertSearchEntry = {
   normalizedTitle: string;
 };
 
+const katakanaToHiragana = (value: string) =>
+  value.replaceAll(/[\u30a1-\u30f6]/g, (character) =>
+    String.fromCharCode(character.charCodeAt(0) - 0x60)
+  );
+
 const normalizeSearchText = (value: string) =>
-  value.normalize('NFKC').toLowerCase().replaceAll(/\s+/g, ' ').trim();
+  katakanaToHiragana(value.normalize('NFKC').toLowerCase()).replaceAll(/\s+/g, ' ').trim();
 
 const splitQueryTokens = (value: string) => normalizeSearchText(value).split(' ').filter(Boolean);
 

--- a/src/lib/posts/search.ts
+++ b/src/lib/posts/search.ts
@@ -1,7 +1,13 @@
-import { getFullTitle, getSearchablePosts, type SearchablePost } from '$lib/posts';
+import {
+  getFullTitle,
+  getPublishedPostMetadata,
+  type PostMetadata,
+  type SearchablePost
+} from '$lib/posts';
 import { composers, type composerSlug } from '$lib/posts/composers';
 import { concerts, type concertSlug } from '$lib/posts/concerts';
 import type { Tag } from '$lib/posts/tags';
+import { convertToDescription, convertToPlainText } from '$lib/util';
 
 export type ArticleSearchResult = {
   slug: string;
@@ -78,6 +84,20 @@ type ConcertSearchEntry = {
   normalizedTitle: string;
 };
 
+type BlogSearchIndex = {
+  articleSearchEntries: ArticleSearchEntry[];
+  tagSearchEntries: TagSearchEntry[];
+  composerSearchEntries: ComposerSearchEntry[];
+  concertSearchEntries: ConcertSearchEntry[];
+};
+
+const emptyBlogSearchResults: BlogSearchResults = {
+  articles: [],
+  tags: [],
+  composers: [],
+  concerts: []
+};
+
 const katakanaToHiragana = (value: string) =>
   value.replaceAll(/[\u30a1-\u30f6]/g, (character) =>
     String.fromCharCode(character.charCodeAt(0) - 0x60)
@@ -91,61 +111,108 @@ const splitQueryTokens = (value: string) => normalizeSearchText(value).split(' '
 const includesAllTokens = (value: string, tokens: string[]) =>
   tokens.length > 0 && tokens.every((token) => value.includes(token));
 
-const publishedPosts = getSearchablePosts();
+let blogSearchIndex: BlogSearchIndex | null = null;
+let blogSearchIndexPromise: Promise<BlogSearchIndex> | null = null;
 
-const articleSearchEntries: ArticleSearchEntry[] = publishedPosts.map((post) =>
-  createArticleSearchEntry(post)
-);
+const rawModules = import.meta.glob('./**/post.svelte', {
+  import: 'default',
+  query: '?raw',
+  eager: true
+}) as Record<string, string>;
 
-const usedComposerTags = new Set<string>(
-  publishedPosts.flatMap((post) => {
-    const slugs = [post.metadata.composerSlug, post.metadata.arrangerSlug].filter(
-      (slug): slug is composerSlug => slug !== undefined
-    );
-
-    return slugs.map((slug) => composers[slug].shortName);
+const rawPostsBySlug = new Map(
+  Object.entries(rawModules).flatMap(([path, rawPost]) => {
+    const slug = /^.+\/(?<slug>[^/]+)\/post\.svelte$/.exec(path)?.groups?.slug;
+    return slug === undefined ? [] : [[slug, rawPost]];
   })
 );
 
-const usedConcertTags = new Set<string>(
-  publishedPosts.map((post) => concerts[post.metadata.concertSlug].title)
-);
+const toSearchablePost = (post: PostMetadata): SearchablePost | null => {
+  const rawPost = rawPostsBySlug.get(post.slug);
+  if (rawPost === undefined) return null;
 
-const tagSearchEntries: TagSearchEntry[] = [
-  ...new Set(publishedPosts.flatMap((post) => post.metadata.tags))
-]
-  .filter((tag) => !usedComposerTags.has(tag) && !usedConcertTags.has(tag))
-  .map((tag) => ({
-    tag,
-    normalizedTag: normalizeSearchText(tag)
-  }));
+  return {
+    ...post,
+    description: convertToDescription(rawPost),
+    searchText: convertToPlainText(rawPost)
+  };
+};
 
-const composerSearchEntries: ComposerSearchEntry[] = [
-  ...new Set(
-    publishedPosts.flatMap((post) =>
-      [post.metadata.composerSlug, post.metadata.arrangerSlug].filter(
+const createBlogSearchIndex = (): BlogSearchIndex => {
+  const publishedPosts = getPublishedPostMetadata()
+    .map((post) => toSearchablePost(post))
+    .filter((post): post is SearchablePost => post !== null);
+
+  const usedComposerTags = new Set<string>(
+    publishedPosts.flatMap((post) => {
+      const slugs = [post.metadata.composerSlug, post.metadata.arrangerSlug].filter(
         (slug): slug is composerSlug => slug !== undefined
-      )
-    )
-  )
-].map((slug) => ({
-  slug,
-  shortName: composers[slug].shortName,
-  fullName: composers[slug].fullName,
-  tag: composers[slug].shortName as Tag,
-  normalizedShortName: normalizeSearchText(composers[slug].shortName),
-  normalizedFullName: normalizeSearchText(composers[slug].fullName)
-}));
+      );
 
-const concertSearchEntries: ConcertSearchEntry[] = [
-  ...new Set(publishedPosts.map((post) => post.metadata.concertSlug))
-].map((slug) => ({
-  slug,
-  title: concerts[slug].title,
-  date: concerts[slug].date,
-  tag: concerts[slug].title as Tag,
-  normalizedTitle: normalizeSearchText(concerts[slug].title)
-}));
+      return slugs.map((slug) => composers[slug].shortName);
+    })
+  );
+
+  const usedConcertTags = new Set<string>(
+    publishedPosts.map((post) => concerts[post.metadata.concertSlug].title)
+  );
+
+  return {
+    articleSearchEntries: publishedPosts.map((post) => createArticleSearchEntry(post)),
+    tagSearchEntries: [...new Set(publishedPosts.flatMap((post) => post.metadata.tags))]
+      .filter((tag) => !usedComposerTags.has(tag) && !usedConcertTags.has(tag))
+      .map((tag) => ({
+        tag,
+        normalizedTag: normalizeSearchText(tag)
+      })),
+    composerSearchEntries: [
+      ...new Set(
+        publishedPosts.flatMap((post) =>
+          [post.metadata.composerSlug, post.metadata.arrangerSlug].filter(
+            (slug): slug is composerSlug => slug !== undefined
+          )
+        )
+      )
+    ].map((slug) => ({
+      slug,
+      shortName: composers[slug].shortName,
+      fullName: composers[slug].fullName,
+      tag: composers[slug].shortName as Tag,
+      normalizedShortName: normalizeSearchText(composers[slug].shortName),
+      normalizedFullName: normalizeSearchText(composers[slug].fullName)
+    })),
+    concertSearchEntries: [...new Set(publishedPosts.map((post) => post.metadata.concertSlug))].map(
+      (slug) => ({
+        slug,
+        title: concerts[slug].title,
+        date: concerts[slug].date,
+        tag: concerts[slug].title as Tag,
+        normalizedTitle: normalizeSearchText(concerts[slug].title)
+      })
+    )
+  };
+};
+
+const getBlogSearchIndex = () => {
+  if (blogSearchIndex !== null) return Promise.resolve(blogSearchIndex);
+  if (blogSearchIndexPromise !== null) return blogSearchIndexPromise;
+
+  blogSearchIndexPromise = Promise.resolve()
+    .then(() => createBlogSearchIndex())
+    .then((index) => {
+      blogSearchIndex = index;
+      return index;
+    })
+    .finally(() => {
+      blogSearchIndexPromise = null;
+    });
+
+  return blogSearchIndexPromise;
+};
+
+export const loadBlogSearchIndex = async (): Promise<void> => {
+  await getBlogSearchIndex();
+};
 
 function createArticleSearchEntry(post: SearchablePost): ArticleSearchEntry {
   const composerNames = [post.metadata.composerSlug, post.metadata.arrangerSlug]
@@ -301,18 +368,14 @@ const scoreConcert = (
 export const searchBlog = (query: string, limitPerSection = 5): BlogSearchResults => {
   const normalizedQuery = normalizeSearchText(query);
   const queryTokens = splitQueryTokens(query);
+  const searchIndex = blogSearchIndex;
 
-  if (normalizedQuery.length === 0 || queryTokens.length === 0) {
-    return {
-      articles: [],
-      tags: [],
-      composers: [],
-      concerts: []
-    };
+  if (normalizedQuery.length === 0 || queryTokens.length === 0 || searchIndex === null) {
+    return emptyBlogSearchResults;
   }
 
   return {
-    articles: articleSearchEntries
+    articles: searchIndex.articleSearchEntries
       .map((entry) => scoreArticle(entry, normalizedQuery, queryTokens))
       .filter((entry): entry is ArticleSearchResult => entry !== null)
       .sort(
@@ -321,12 +384,12 @@ export const searchBlog = (query: string, limitPerSection = 5): BlogSearchResult
           new Date(entryB.publishedAt).getTime() - new Date(entryA.publishedAt).getTime()
       )
       .slice(0, limitPerSection),
-    tags: tagSearchEntries
+    tags: searchIndex.tagSearchEntries
       .map((entry) => scoreTag(entry, normalizedQuery, queryTokens))
       .filter((entry): entry is TagSearchResult => entry !== null)
       .sort((entryA, entryB) => entryB.score - entryA.score || entryA.tag.localeCompare(entryB.tag))
       .slice(0, limitPerSection),
-    composers: composerSearchEntries
+    composers: searchIndex.composerSearchEntries
       .map((entry) => scoreComposer(entry, normalizedQuery, queryTokens))
       .filter((entry): entry is ComposerSearchResult => entry !== null)
       .sort(
@@ -334,7 +397,7 @@ export const searchBlog = (query: string, limitPerSection = 5): BlogSearchResult
           entryB.score - entryA.score || entryA.shortName.localeCompare(entryB.shortName)
       )
       .slice(0, limitPerSection),
-    concerts: concertSearchEntries
+    concerts: searchIndex.concertSearchEntries
       .map((entry) => scoreConcert(entry, normalizedQuery, queryTokens))
       .filter((entry): entry is ConcertSearchResult => entry !== null)
       .sort(

--- a/src/lib/posts/search.ts
+++ b/src/lib/posts/search.ts
@@ -1,0 +1,342 @@
+import { getFullTitle, getSearchablePosts, type SearchablePost } from '$lib/posts';
+import { composers, type composerSlug } from '$lib/posts/composers';
+import { concerts, type concertSlug } from '$lib/posts/concerts';
+import type { Tag } from '$lib/posts/tags';
+
+export type ArticleSearchResult = {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  tags: Tag[];
+  matchedFieldLabel: 'タイトル一致' | 'タグ一致' | '関連情報一致' | '本文一致';
+  score: number;
+};
+
+export type TagSearchResult = {
+  tag: Tag;
+  score: number;
+};
+
+export type ComposerSearchResult = {
+  slug: composerSlug;
+  shortName: string;
+  fullName: string;
+  tag: Tag;
+  score: number;
+};
+
+export type ConcertSearchResult = {
+  slug: concertSlug;
+  title: string;
+  date: string;
+  tag: Tag;
+  score: number;
+};
+
+export type BlogSearchResults = {
+  articles: ArticleSearchResult[];
+  tags: TagSearchResult[];
+  composers: ComposerSearchResult[];
+  concerts: ConcertSearchResult[];
+};
+
+type ArticleSearchEntry = {
+  slug: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  tags: Tag[];
+  normalizedTitle: string;
+  normalizedDescription: string;
+  normalizedSearchText: string;
+  normalizedTags: string[];
+  normalizedComposerNames: string[];
+  normalizedConcertTitle: string;
+  normalizedCombinedText: string;
+};
+
+type TagSearchEntry = {
+  tag: Tag;
+  normalizedTag: string;
+};
+
+type ComposerSearchEntry = {
+  slug: composerSlug;
+  shortName: string;
+  fullName: string;
+  tag: Tag;
+  normalizedShortName: string;
+  normalizedFullName: string;
+};
+
+type ConcertSearchEntry = {
+  slug: concertSlug;
+  title: string;
+  date: string;
+  tag: Tag;
+  normalizedTitle: string;
+};
+
+const normalizeSearchText = (value: string) =>
+  value.normalize('NFKC').toLowerCase().replaceAll(/\s+/g, ' ').trim();
+
+const splitQueryTokens = (value: string) => normalizeSearchText(value).split(' ').filter(Boolean);
+
+const includesAllTokens = (value: string, tokens: string[]) =>
+  tokens.length > 0 && tokens.every((token) => value.includes(token));
+
+const publishedPosts = getSearchablePosts();
+
+const articleSearchEntries: ArticleSearchEntry[] = publishedPosts.map((post) =>
+  createArticleSearchEntry(post)
+);
+
+const usedComposerTags = new Set<string>(
+  publishedPosts.flatMap((post) => {
+    const slugs = [post.metadata.composerSlug, post.metadata.arrangerSlug].filter(
+      (slug): slug is composerSlug => slug !== undefined
+    );
+
+    return slugs.map((slug) => composers[slug].shortName);
+  })
+);
+
+const usedConcertTags = new Set<string>(
+  publishedPosts.map((post) => concerts[post.metadata.concertSlug].title)
+);
+
+const tagSearchEntries: TagSearchEntry[] = [
+  ...new Set(publishedPosts.flatMap((post) => post.metadata.tags))
+]
+  .filter((tag) => !usedComposerTags.has(tag) && !usedConcertTags.has(tag))
+  .map((tag) => ({
+    tag,
+    normalizedTag: normalizeSearchText(tag)
+  }));
+
+const composerSearchEntries: ComposerSearchEntry[] = [
+  ...new Set(
+    publishedPosts.flatMap((post) =>
+      [post.metadata.composerSlug, post.metadata.arrangerSlug].filter(
+        (slug): slug is composerSlug => slug !== undefined
+      )
+    )
+  )
+].map((slug) => ({
+  slug,
+  shortName: composers[slug].shortName,
+  fullName: composers[slug].fullName,
+  tag: composers[slug].shortName as Tag,
+  normalizedShortName: normalizeSearchText(composers[slug].shortName),
+  normalizedFullName: normalizeSearchText(composers[slug].fullName)
+}));
+
+const concertSearchEntries: ConcertSearchEntry[] = [
+  ...new Set(publishedPosts.map((post) => post.metadata.concertSlug))
+].map((slug) => ({
+  slug,
+  title: concerts[slug].title,
+  date: concerts[slug].date,
+  tag: concerts[slug].title as Tag,
+  normalizedTitle: normalizeSearchText(concerts[slug].title)
+}));
+
+function createArticleSearchEntry(post: SearchablePost): ArticleSearchEntry {
+  const composerNames = [post.metadata.composerSlug, post.metadata.arrangerSlug]
+    .filter((slug): slug is composerSlug => slug !== undefined)
+    .flatMap((slug) => {
+      const composer = composers[slug];
+      return [composer.shortName, composer.fullName];
+    });
+  const concertTitle = concerts[post.metadata.concertSlug].title;
+  const title = getFullTitle(post);
+
+  return {
+    slug: post.slug,
+    title,
+    description: post.description,
+    publishedAt: post.metadata.publicatedAt,
+    tags: post.metadata.tags,
+    normalizedTitle: normalizeSearchText(title),
+    normalizedDescription: normalizeSearchText(post.description),
+    normalizedSearchText: normalizeSearchText(post.searchText),
+    normalizedTags: post.metadata.tags.map((tag) => normalizeSearchText(tag)),
+    normalizedComposerNames: composerNames.map((name) => normalizeSearchText(name)),
+    normalizedConcertTitle: normalizeSearchText(concertTitle),
+    normalizedCombinedText: normalizeSearchText(
+      [
+        title,
+        post.description,
+        post.searchText,
+        ...post.metadata.tags,
+        ...composerNames,
+        concertTitle
+      ].join(' ')
+    )
+  };
+}
+
+const scoreArticle = (
+  entry: ArticleSearchEntry,
+  normalizedQuery: string,
+  queryTokens: string[]
+): ArticleSearchResult | null => {
+  if (!includesAllTokens(entry.normalizedCombinedText, queryTokens)) return null;
+
+  const titlePrefixMatch = entry.normalizedTitle.startsWith(normalizedQuery);
+  const titleMatch = includesAllTokens(entry.normalizedTitle, queryTokens);
+  const tagMatch = entry.normalizedTags.some((tag) => includesAllTokens(tag, queryTokens));
+  const composerMatch = entry.normalizedComposerNames.some((name) =>
+    includesAllTokens(name, queryTokens)
+  );
+  const concertMatch = includesAllTokens(entry.normalizedConcertTitle, queryTokens);
+  const bodyMatch =
+    includesAllTokens(entry.normalizedSearchText, queryTokens) ||
+    includesAllTokens(entry.normalizedDescription, queryTokens);
+
+  let score = 0;
+  let matchedFieldLabel: ArticleSearchResult['matchedFieldLabel'] = '本文一致';
+
+  if (titlePrefixMatch) {
+    score += 420;
+    matchedFieldLabel = 'タイトル一致';
+  } else if (titleMatch) {
+    score += 300;
+    matchedFieldLabel = 'タイトル一致';
+  }
+
+  if (tagMatch) {
+    score += 160;
+    if (matchedFieldLabel === '本文一致') matchedFieldLabel = 'タグ一致';
+  }
+
+  if (composerMatch || concertMatch) {
+    score += 140;
+    if (matchedFieldLabel === '本文一致') matchedFieldLabel = '関連情報一致';
+  }
+
+  if (bodyMatch) {
+    score += 90;
+  }
+
+  if (score === 0) {
+    score = 60;
+  }
+
+  return {
+    slug: entry.slug,
+    title: entry.title,
+    description: entry.description,
+    publishedAt: entry.publishedAt,
+    tags: entry.tags,
+    matchedFieldLabel,
+    score
+  };
+};
+
+const scoreTag = (
+  entry: TagSearchEntry,
+  normalizedQuery: string,
+  queryTokens: string[]
+): TagSearchResult | null => {
+  if (!includesAllTokens(entry.normalizedTag, queryTokens)) return null;
+
+  let score = 120;
+  if (entry.normalizedTag.startsWith(normalizedQuery)) score += 80;
+
+  return {
+    tag: entry.tag,
+    score
+  };
+};
+
+const scoreComposer = (
+  entry: ComposerSearchEntry,
+  normalizedQuery: string,
+  queryTokens: string[]
+): ComposerSearchResult | null => {
+  const shortNameMatch = includesAllTokens(entry.normalizedShortName, queryTokens);
+  const fullNameMatch = includesAllTokens(entry.normalizedFullName, queryTokens);
+
+  if (!shortNameMatch && !fullNameMatch) return null;
+
+  let score = 140;
+  if (entry.normalizedShortName.startsWith(normalizedQuery)) score += 100;
+  if (entry.normalizedFullName.startsWith(normalizedQuery)) score += 40;
+
+  return {
+    slug: entry.slug,
+    shortName: entry.shortName,
+    fullName: entry.fullName,
+    tag: entry.tag,
+    score
+  };
+};
+
+const scoreConcert = (
+  entry: ConcertSearchEntry,
+  normalizedQuery: string,
+  queryTokens: string[]
+): ConcertSearchResult | null => {
+  if (!includesAllTokens(entry.normalizedTitle, queryTokens)) return null;
+
+  let score = 140;
+  if (entry.normalizedTitle.startsWith(normalizedQuery)) score += 90;
+
+  return {
+    slug: entry.slug,
+    title: entry.title,
+    date: entry.date,
+    tag: entry.tag,
+    score
+  };
+};
+
+export const searchBlog = (query: string, limitPerSection = 5): BlogSearchResults => {
+  const normalizedQuery = normalizeSearchText(query);
+  const queryTokens = splitQueryTokens(query);
+
+  if (normalizedQuery.length === 0 || queryTokens.length === 0) {
+    return {
+      articles: [],
+      tags: [],
+      composers: [],
+      concerts: []
+    };
+  }
+
+  return {
+    articles: articleSearchEntries
+      .map((entry) => scoreArticle(entry, normalizedQuery, queryTokens))
+      .filter((entry): entry is ArticleSearchResult => entry !== null)
+      .sort(
+        (entryA, entryB) =>
+          entryB.score - entryA.score ||
+          new Date(entryB.publishedAt).getTime() - new Date(entryA.publishedAt).getTime()
+      )
+      .slice(0, limitPerSection),
+    tags: tagSearchEntries
+      .map((entry) => scoreTag(entry, normalizedQuery, queryTokens))
+      .filter((entry): entry is TagSearchResult => entry !== null)
+      .sort((entryA, entryB) => entryB.score - entryA.score || entryA.tag.localeCompare(entryB.tag))
+      .slice(0, limitPerSection),
+    composers: composerSearchEntries
+      .map((entry) => scoreComposer(entry, normalizedQuery, queryTokens))
+      .filter((entry): entry is ComposerSearchResult => entry !== null)
+      .sort(
+        (entryA, entryB) =>
+          entryB.score - entryA.score || entryA.shortName.localeCompare(entryB.shortName)
+      )
+      .slice(0, limitPerSection),
+    concerts: concertSearchEntries
+      .map((entry) => scoreConcert(entry, normalizedQuery, queryTokens))
+      .filter((entry): entry is ConcertSearchResult => entry !== null)
+      .sort(
+        (entryA, entryB) =>
+          entryB.score - entryA.score ||
+          new Date(entryB.date).getTime() - new Date(entryA.date).getTime()
+      )
+      .slice(0, limitPerSection)
+  };
+};

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -7,17 +7,27 @@ export const formatDate2JpStyle = (date: string) =>
   `${new Date(date).getFullYear()}/${new Date(date).getMonth() + 1}/${new Date(date).getDate()}`;
 
 /**
- * descriptionとして用いられる冒頭抽出文字列を生成する。
+ * ポストの生テキストから検索用のプレーンテキストを生成する。
  * @param rawPost ポストのHTML文字列
- * @returns 冒頭を抽出した文字列
+ * @returns タグ類を除去したプレーンテキスト
  */
-export const convertToDescription = (rawPost: string) =>
+export const convertToPlainText = (rawPost: string) =>
   rawPost
     .replaceAll(/<script.+?<\/script>/gs, '') // スクリプトを削除
     .replaceAll(/<style.+?<\/style>/gs, '') // スタイリングを削除
     .replaceAll(/<h\d.+?<\/h\d>/gs, '') // ヘッダーを削除
     .replaceAll(/<figcaption.+?<\/figcaption>/gs, '') // キャプションを削除
     .replaceAll(/<.+?>/gs, '') // タグ文字列を削除
+    .replaceAll(/\s+/gs, ' ') // 空白を圧縮
+    .trim();
+
+/**
+ * descriptionとして用いられる冒頭抽出文字列を生成する。
+ * @param rawPost ポストのHTML文字列
+ * @returns 冒頭を抽出した文字列
+ */
+export const convertToDescription = (rawPost: string) =>
+  convertToPlainText(rawPost)
     .replaceAll(/\s+/gs, '') // 空白を削除
     .substring(0, 200);
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { PageData } from './$types';
-  import PostList from '$lib/component/PostList.svelte';
   import Meta from '$lib/component/Meta.svelte';
+  import SearchablePostList from '$lib/component/SearchablePostList.svelte';
 
   interface Props {
     data: PageData;
@@ -12,7 +12,8 @@
 
 <Meta title="" canonical="/" />
 
-<PostList
+<SearchablePostList
+  heading="記事一覧"
   posts={data.posts}
   currentPageNumber={data.currentPageNumber}
   totalNumberOfPages={data.totalNumberOfPages}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,10 +1,10 @@
-import { getPosts } from '$lib/posts';
+import { getPostCount, getPostListItems } from '$lib/posts';
 import { PostCountInOnePage } from '$lib/util';
 import { error, redirect } from '@sveltejs/kit';
 
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = ({ url }) => {
+export const load: PageLoad = async ({ url }) => {
   // URLからpageNumberを取得
   const rawPageNumber = url.searchParams.get('p');
   let pageNumber: number;
@@ -24,13 +24,16 @@ export const load: PageLoad = ({ url }) => {
   }
 
   // ポストを取得する
-  const posts = getPosts();
-  const totalNumberOfPages = Math.ceil(posts.length / PostCountInOnePage);
+  const totalNumberOfPosts = getPostCount();
+  const totalNumberOfPages = Math.ceil(totalNumberOfPosts / PostCountInOnePage);
   // インデックス範囲外には404を
   if (totalNumberOfPages < pageNumber) error(404);
 
   return {
-    posts: posts.slice(PostCountInOnePage * (pageNumber - 1), PostCountInOnePage * pageNumber),
+    posts: await getPostListItems({
+      offset: PostCountInOnePage * (pageNumber - 1),
+      limit: PostCountInOnePage
+    }),
     currentPageNumber: pageNumber,
     totalNumberOfPages: totalNumberOfPages
   };

--- a/src/routes/post/[slug]/+page.ts
+++ b/src/routes/post/[slug]/+page.ts
@@ -6,11 +6,11 @@ import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params }) => {
   // slugが一致する記事がない、未publishの場合は404
-  const post = getPostBySlug(params.slug);
+  const post = await getPostBySlug(params.slug);
   if (post === null) error(404);
   if (!post.metadata.published) error(404);
 
-  const adjacentPostListItems = getAdjacentPostListItemsBySlug(params.slug);
+  const adjacentPostListItems = await getAdjacentPostListItemsBySlug(params.slug);
 
   return {
     post: post,

--- a/src/routes/tag/[tag=tag]/+page.svelte
+++ b/src/routes/tag/[tag=tag]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { PageData } from './$types';
-  import PostList from '$lib/component/PostList.svelte';
   import Meta from '$lib/component/Meta.svelte';
+  import SearchablePostList from '$lib/component/SearchablePostList.svelte';
 
   interface Props {
     data: PageData;
@@ -12,23 +12,11 @@
 
 <Meta title={`#${data.tag}の記事一覧`} canonical={`/tag/${data.tag}`} />
 
-<p>#&thinsp;{data.tag}の記事：{data.totalNumberOfPosts}件</p>
-
-<PostList
+<SearchablePostList
+  heading={`#${data.tag}の記事一覧`}
+  summary={`${data.totalNumberOfPosts}件`}
   posts={data.posts}
   tag={data.tag}
   currentPageNumber={data.currentPageNumber}
   totalNumberOfPages={data.totalNumberOfPages}
 />
-
-<style>
-  p {
-    text-indent: 0;
-    margin-left: calc(var(--spacing-unit) * 4);
-  }
-  @media (max-width: 576px) {
-    p {
-      margin-left: 0;
-    }
-  }
-</style>

--- a/src/routes/tag/[tag=tag]/+page.ts
+++ b/src/routes/tag/[tag=tag]/+page.ts
@@ -1,11 +1,11 @@
 import { error, redirect } from '@sveltejs/kit';
 
-import { getPosts } from '$lib/posts';
+import { getPostCount, getPostListItems } from '$lib/posts';
 import { PostCountInOnePage } from '$lib/util';
 
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = ({ params, url }) => {
+export const load: PageLoad = async ({ params, url }) => {
   // URLからpageNumberを取得
   const rawPageNumber = url.searchParams.get('p');
   let pageNumber: number;
@@ -25,17 +25,21 @@ export const load: PageLoad = ({ params, url }) => {
   }
 
   // ポストを取得する
-  const posts = getPosts(params.tag);
-  if (posts.length === 0) error(404); // 該当するタグの記事がなければ404
+  const totalNumberOfPosts = getPostCount(params.tag);
+  if (totalNumberOfPosts === 0) error(404); // 該当するタグの記事がなければ404
 
   // インデックス範囲外には404を
-  const totalNumberOfPages = Math.ceil(posts.length / PostCountInOnePage);
+  const totalNumberOfPages = Math.ceil(totalNumberOfPosts / PostCountInOnePage);
   if (totalNumberOfPages < pageNumber) error(404);
 
   return {
     tag: params.tag,
-    totalNumberOfPosts: posts.length,
-    posts: posts.slice(PostCountInOnePage * (pageNumber - 1), PostCountInOnePage * pageNumber),
+    totalNumberOfPosts,
+    posts: await getPostListItems({
+      filterTag: params.tag,
+      offset: PostCountInOnePage * (pageNumber - 1),
+      limit: PostCountInOnePage
+    }),
     currentPageNumber: pageNumber,
     totalNumberOfPages: totalNumberOfPages
   };


### PR DESCRIPTION
## Summary
- add a searchable list wrapper for the blog index and tag list pages
- place a design-consistent search field under each list heading and open an overlay search palette from focus or `Ctrl+K` / `Cmd+K`
- add lightweight client-side search indexing for articles, tags, composers, and concerts without introducing an external search service

## Why
The blog only offered paginated browsing, so jumping to relevant articles required manual scanning across index and tag pages. A lightweight search overlay improves discovery while staying within the existing static-data architecture.

## Impact
- `/` and `/tag/[tag]` now show a search field above the paginated post list
- search results are grouped by type, with articles as the primary results and supporting navigation for tags, composers, and concerts
- keyboard and overlay behavior now includes focus management, close actions, and background scroll locking while search is open

## Validation
- `npm run check`
- `npm run lint`
- `npm run build`
- manual preview verification for `/` and `/tag/チャイコフスキー`

## Review
- closes #51
- subagent review: no findings