### PR TITLE
Refine blog frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 /build
 /.svelte-kit
+/.wrangler
 /package
 .env
 .env.*

--- a/src/app.html
+++ b/src/app.html
@@ -1,11 +1,13 @@
-<html>
+<!doctype html>
+<html lang="ja">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#0a0606" />
     <link rel="icon" href="/favicon.png" />
     %sveltekit.head%
   </head>
-  <body>
+  <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>
 
     <script>

--- a/src/lib/component/BlogSearch.svelte
+++ b/src/lib/component/BlogSearch.svelte
@@ -289,12 +289,6 @@
           spellcheck="false"
           aria-keyshortcuts="Control+K Meta+K"
         />
-        <span class="input-shortcut-hint" aria-hidden="true">
-          <kbd>Ctrl</kbd>
-          <span>+</span>
-          <kbd>K</kbd>
-          <span class="mac-shortcut">/ ⌘K</span>
-        </span>
       </div>
       <p class="sr-only" role="status" aria-live="polite">{resultStatusText}</p>
 
@@ -417,11 +411,11 @@
     align-items: center;
     width: calc(var(--spacing-unit) * 11);
     height: calc(var(--spacing-unit) * 11);
-    border: 1px solid rgba(0, 0, 0, 0.16);
-    border-radius: calc(var(--spacing-unit) * 2);
+    border: 1px solid var(--color-text-secondary);
+    border-radius: var(--spacing-unit);
     padding: 0;
     background-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-primary);
     cursor: pointer;
     transition:
       background-color 0.2s ease,
@@ -437,43 +431,46 @@
   }
 
   .search-trigger:hover {
-    background-color: rgba(0, 0, 0, 0.06);
-    border-color: rgba(0, 0, 0, 0.28);
+    background-color: var(--color-surface-raised);
+    border-color: var(--color-text-secondary);
     color: var(--color-text-primary);
   }
 
   .search-trigger:focus-visible {
-    outline: none;
-    background-color: rgba(0, 0, 0, 0.08);
-    border-color: rgba(0, 0, 0, 0.32);
+    background-color: var(--color-surface-raised);
+    border-color: var(--color-text-primary);
     color: var(--color-text-primary);
   }
 
   .close-button:hover {
-    border-color: var(--color-text-primary);
-    background-color: rgba(238, 238, 238, 0.8);
+    border-color: var(--color-text-secondary);
+    background-color: var(--color-surface-raised);
   }
 
   .close-button:focus-visible {
-    outline: 2px solid var(--color-text-primary);
-    outline-offset: 2px;
+    border-color: var(--color-text-primary);
   }
 
   .search-input {
     box-sizing: border-box;
     width: 100%;
-    border: 1px solid var(--color-text-primary);
-    border-radius: calc(var(--spacing-unit) * 2);
-    padding: calc(var(--spacing-unit) * 4) calc(var(--spacing-unit) * 34)
-      calc(var(--spacing-unit) * 4) calc(var(--spacing-unit) * 5);
+    min-height: 52px;
+    border: 1px solid var(--color-text-secondary);
+    border-radius: var(--spacing-unit);
+    padding: calc(var(--spacing-unit) * 4) calc(var(--spacing-unit) * 5);
     font: inherit;
     font-size: 1.05rem;
-    background-color: rgba(255, 255, 255, 0.92);
-    color: inherit;
+    background-color: var(--color-surface-raised);
+    color: var(--color-text-primary);
+    caret-color: var(--color-text-primary);
+  }
+
+  .search-input:focus {
+    border-color: var(--color-text-primary);
   }
 
   .search-input::placeholder {
-    color: var(--color-text-secondary);
+    color: #c6c0bd;
     opacity: 1;
   }
 
@@ -484,7 +481,7 @@
     display: grid;
     place-items: start center;
     overflow-y: auto;
-    padding: calc(var(--spacing-unit) * 8);
+    padding: calc(var(--spacing-unit) * 12) calc(var(--spacing-unit) * 8);
   }
 
   .search-backdrop {
@@ -492,8 +489,8 @@
     inset: 0;
     border: 0;
     padding: 0;
-    background: rgba(238, 238, 238, 0.7);
-    backdrop-filter: blur(6px);
+    background: rgba(10, 6, 6, 0.86);
+    backdrop-filter: blur(8px);
   }
 
   .search-dialog {
@@ -502,14 +499,14 @@
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    gap: calc(var(--spacing-unit) * 4);
-    width: min(100%, 760px);
-    max-height: min(80vh, 760px);
-    border: 1px solid var(--color-text-primary);
-    border-radius: calc(var(--spacing-unit) * 3);
+    gap: calc(var(--spacing-unit) * 5);
+    width: min(100%, 780px);
+    max-height: min(calc(100dvh - var(--spacing-unit) * 24), 780px);
+    border: 1px solid var(--color-border);
+    border-radius: calc(var(--spacing-unit) * 2);
     padding: calc(var(--spacing-unit) * 6);
-    background-color: rgba(255, 255, 255, 0.92);
-    box-shadow: 0 0 24px rgba(0, 0, 0, 0.16);
+    background-color: var(--color-surface);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
   }
 
   .search-dialog-header {
@@ -526,8 +523,9 @@
   }
 
   .search-dialog-title {
-    font-family: var(--serif);
-    font-size: 1.25rem;
+    font-family: var(--display-font);
+    font-size: 1.125rem;
+    font-weight: 500;
     margin: 0;
   }
 
@@ -536,10 +534,10 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    width: calc(var(--spacing-unit) * 10);
-    height: calc(var(--spacing-unit) * 10);
-    border: 1px solid var(--color-text-primary);
-    border-radius: calc(var(--spacing-unit) * 2);
+    width: calc(var(--spacing-unit) * 11);
+    height: calc(var(--spacing-unit) * 11);
+    border: 1px solid var(--color-border);
+    border-radius: var(--spacing-unit);
     padding: 0;
     background: transparent;
     color: inherit;
@@ -555,28 +553,10 @@
     align-items: center;
   }
 
-  .input-shortcut-hint {
-    position: absolute;
-    right: calc(var(--spacing-unit) * 4);
-    display: inline-flex;
-    align-items: center;
-    gap: calc(var(--spacing-unit) * 1);
-    font-size: 0.78em;
-    color: var(--color-text-secondary);
-    pointer-events: none;
-  }
-
-  .input-shortcut-hint kbd {
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    border-radius: calc(var(--spacing-unit) * 1.5);
-    padding: 0 calc(var(--spacing-unit) * 1.5);
-    font-family: inherit;
-    font-size: 0.95em;
-    background-color: rgba(255, 255, 255, 0.75);
-  }
-
   .search-results {
+    min-height: 0;
     overflow-y: auto;
+    scrollbar-color: var(--color-text-secondary) var(--color-surface);
   }
 
   .search-sections {
@@ -587,15 +567,17 @@
 
   .result-section h3 {
     margin-top: 0;
-    margin-bottom: calc(var(--spacing-unit) * 3);
-    font-size: 1rem;
+    margin-bottom: calc(var(--spacing-unit) * 2);
+    font-family: var(--display-font);
+    font-size: 0.75rem;
+    font-weight: 500;
     color: var(--color-text-secondary);
   }
 
   .result-list {
     display: flex;
     flex-direction: column;
-    gap: calc(var(--spacing-unit) * 3);
+    gap: 0;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -606,19 +588,30 @@
     display: flex;
     flex-direction: column;
     gap: calc(var(--spacing-unit) * 2);
-    border: 1px solid rgba(0, 0, 0, 0.14);
-    border-radius: calc(var(--spacing-unit) * 2);
-    padding: calc(var(--spacing-unit) * 4);
+    min-height: 44px;
+    border-top: 1px solid var(--color-border);
+    padding: calc(var(--spacing-unit) * 4) calc(var(--spacing-unit) * 2);
     transition:
       background-color 0.2s ease,
       border-color 0.2s ease;
   }
 
+  .result-list li:last-child .article-result,
+  .result-list li:last-child .compact-result {
+    border-bottom: 1px solid var(--color-border);
+  }
+
   .article-result:hover,
   .compact-result:hover {
-    border-color: var(--color-text-primary);
-    background-color: rgba(238, 238, 238, 0.8);
+    border-color: var(--color-border);
+    background-color: var(--color-surface-raised);
     text-decoration: none;
+  }
+
+  .article-result:focus-visible,
+  .compact-result:focus-visible {
+    position: relative;
+    z-index: 1;
   }
 
   .article-result strong,
@@ -643,9 +636,7 @@
 
   .match-label {
     display: inline-block;
-    border: 1px solid rgba(0, 0, 0, 0.18);
-    border-radius: 999px;
-    padding: 0 calc(var(--spacing-unit) * 2);
+    padding: 0;
     color: var(--color-text-secondary);
   }
 
@@ -695,13 +686,16 @@
 
   @media (max-width: 576px) {
     .search-layer {
-      padding: calc(var(--spacing-unit) * 4);
+      padding: 0;
     }
 
     .search-dialog {
-      min-height: calc(100vh - var(--spacing-unit) * 8);
-      max-height: calc(100vh - var(--spacing-unit) * 8);
-      padding: calc(var(--spacing-unit) * 5);
+      width: 100%;
+      min-height: 100dvh;
+      max-height: 100dvh;
+      border: 0;
+      border-radius: 0;
+      padding: calc(var(--spacing-unit) * 4);
     }
 
     .search-dialog-header {
@@ -713,11 +707,7 @@
     }
 
     .search-input {
-      padding-right: calc(var(--spacing-unit) * 20);
-    }
-
-    .input-shortcut-hint .mac-shortcut {
-      display: none;
+      padding-right: calc(var(--spacing-unit) * 5);
     }
 
     .article-result-meta {

--- a/src/lib/component/CookieConcent.svelte
+++ b/src/lib/component/CookieConcent.svelte
@@ -138,12 +138,23 @@
   <!-- End Cloudflare Web Analytics -->
 </svelte:head>
 
-<div class="toast" class:show={showToast}>
-  <p>
+<div
+  class="toast"
+  class:show={showToast}
+  role="region"
+  aria-live="polite"
+  aria-labelledby="cookie-consent-title"
+  aria-describedby="cookie-consent-description cookie-consent-request"
+  aria-hidden={!showToast}
+>
+  <h2 id="cookie-consent-title">Cookieの設定</h2>
+  <p id="cookie-consent-description">
     このブログでは、サービスの品質向上と利用状況の把握のためにCookieを使用しています。<br />
     詳細は<a href={resolve('/cookie-policy')}>Cookieポリシー</a>をご確認ください。
   </p>
-  <p>Cookieの使用に同意いただける場合は、「同意する」をクリックしてください。</p>
+  <p id="cookie-consent-request">
+    Cookieの使用に同意いただける場合は、「同意する」を選択してください。
+  </p>
 
   <div class="button-container">
     <button
@@ -177,7 +188,6 @@
   >
     Cookieの設定を変更
   </button>
-  ・
   <a class="secondary-link" href={resolve('/cookie-policy')}>Cookieポリシー</a>
 </div>
 
@@ -185,7 +195,6 @@
   button {
     padding: 0;
     border: none;
-    outline: none;
     font: inherit;
     color: inherit;
     background: none;
@@ -195,92 +204,129 @@
   .text-link {
     color: var(--color-text-secondary);
     text-decoration: underline;
+    text-underline-offset: 0.2em;
   }
 
   .toast {
     position: fixed;
     bottom: calc(var(--spacing-unit) * 8);
-    z-index: 2;
+    left: 50%;
+    z-index: 20;
 
-    margin: 0 calc(var(--spacing-unit) * 8);
-    border: 1px solid var(--color-text-primary);
+    width: min(calc(100% - var(--spacing-unit) * 8), 720px);
+    margin: 0;
+    border: 1px solid var(--color-border);
     padding: calc(var(--spacing-unit) * 6);
 
-    box-shadow: 0 0 15px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 20px 56px rgba(0, 0, 0, 0.48);
     border-radius: var(--spacing-unit);
 
-    background-color: rgba(255, 255, 255, 0.75);
-    backdrop-filter: blur(5px);
+    background-color: var(--color-surface-raised);
+    color: var(--color-text-primary);
 
-    animation: fadeOut 0.1s ease-in 0s forwards;
     display: none;
     opacity: 0;
+    transform: translate(-50%, calc(var(--spacing-unit) * 2));
+
+    h2 {
+      margin: 0 0 calc(var(--spacing-unit) * 4);
+      font-family: var(--display-font);
+      font-size: 1rem;
+      font-weight: 500;
+    }
 
     p {
       margin-top: 0;
       margin-bottom: calc(var(--spacing-unit) * 4);
     }
-
-    button {
-      padding: calc(var(--spacing-unit) * 1) calc(var(--spacing-unit) * 4);
-      border: 1px solid var(--color-text-primary);
-      border-radius: var(--spacing-unit);
-    }
   }
 
   .show {
-    animation: fadeIn 0.1s ease-in 0s forwards;
+    animation: fadeIn 160ms ease-out forwards;
 
     display: block;
     opacity: 1;
   }
 
   @keyframes fadeIn {
-    0% {
-      display: none;
+    from {
       opacity: 0;
-      transform: scale(0.95);
+      transform: translate(-50%, calc(var(--spacing-unit) * 2));
     }
-    1% {
-      display: block;
-      opacity: 0;
-    }
-    100% {
-      display: block;
+    to {
       opacity: 1;
-      transform: scale(1);
+      transform: translate(-50%, 0);
     }
   }
 
-  @keyframes fadeOut {
-    0% {
-      display: block;
-      opacity: 1;
-      transform: scale(1);
-    }
-    99% {
-      display: block;
-      opacity: 0;
-    }
-    100% {
-      display: none;
-      opacity: 0;
-      transform: scale(0.95);
-    }
+  .toast a {
+    color: var(--color-text-primary);
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
   }
 
   .button-container {
     display: flex;
+    flex-wrap: wrap;
     justify-content: flex-end;
-    gap: calc(var(--spacing-unit) * 6);
+    gap: calc(var(--spacing-unit) * 3);
   }
 
-  a {
-    text-decoration: underline;
+  .button-container button {
+    min-height: 44px;
+    border: 1px solid var(--color-text-secondary);
+    border-radius: var(--spacing-unit);
+    padding: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 5);
+    transition:
+      background-color 160ms ease,
+      border-color 160ms ease,
+      color 160ms ease;
+  }
+
+  .button-container button:first-child {
+    border-color: var(--color-inverse-background);
+    background: var(--color-inverse-background);
+    color: var(--color-inverse-text);
+  }
+
+  .button-container button:hover {
+    border-color: var(--color-text-primary);
+  }
+
+  .button-container button:not(:first-child):hover {
+    background: var(--color-surface);
   }
 
   .footer-section {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 5);
     color: var(--color-text-secondary);
-    font-size: 0.8em;
+    font-size: 0.75rem;
+  }
+
+  .footer-section button,
+  .footer-section a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+  }
+
+  .secondary-link {
+    color: var(--color-text-secondary);
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+
+  @media (max-width: 576px) {
+    .toast {
+      bottom: calc(var(--spacing-unit) * 4);
+      padding: calc(var(--spacing-unit) * 4);
+    }
+
+    .button-container button {
+      flex: 1 1 120px;
+    }
   }
 </style>

--- a/src/lib/component/Flyer.svelte
+++ b/src/lib/component/Flyer.svelte
@@ -4,9 +4,10 @@
   interface Props {
     src: string;
     alt: string;
+    loading?: 'eager' | 'lazy';
   }
 
-  let { src, alt }: Props = $props();
+  let { src, alt, loading = 'lazy' }: Props = $props();
   const commonOptions = [
     ['format', 'auto'],
     ['fit', 'scale-down']
@@ -31,14 +32,19 @@
     src={getCloudflareSrc(src, [...commonOptions, ['height', '400']])}
     srcset={`${getCloudflareSrc(src, [...commonOptions, ['height', '800']])} 2x`}
     {alt}
+    {loading}
+    decoding="async"
   />
 {:else if useCloudflareImages === false}
-  <img {src} {alt} />
+  <img {src} {alt} {loading} decoding="async" />
 {/if}
 
 <style>
   img {
+    display: block;
     max-height: 400px;
+    height: auto;
     width: 100%;
+    object-fit: contain;
   }
 </style>

--- a/src/lib/component/PostList.svelte
+++ b/src/lib/component/PostList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { getFullTitle, type PostListItem } from '$lib/posts';
+  import { concerts } from '$lib/posts/concerts';
   import type { Tag } from '$lib/posts/tags';
   import { formatDate2JpStyle } from '$lib/util';
   import TagList from './TagList.svelte';
@@ -14,9 +15,17 @@
     currentPageNumber: number;
     /** 総ページ数 */
     totalNumberOfPages: number;
+    /** 記事タイトルの見出しレベル */
+    headingLevel?: 2 | 3;
   }
 
-  let { posts, tag = undefined, currentPageNumber, totalNumberOfPages }: Props = $props();
+  let {
+    posts,
+    tag = undefined,
+    currentPageNumber,
+    totalNumberOfPages,
+    headingLevel = 2
+  }: Props = $props();
 </script>
 
 <!--
@@ -36,204 +45,202 @@
 ```
 -->
 
-<main class="article-list">
+<div class="article-list">
   {#each posts as post (post.slug)}
-    <div class="article">
-      <div class="meta-container">
-        <TagList tags={post.metadata.tags} />
-        <div class="date for-large-screen">
+    <article class="article">
+      <header class="meta-container">
+        <span>{concerts[post.metadata.concertSlug].title}</span>
+        <time datetime={post.metadata.publicatedAt}>
           {formatDate2JpStyle(post.metadata.publicatedAt)}
-        </div>
-      </div>
+        </time>
+      </header>
 
       <a href={resolve('/post/[slug]', { slug: post.slug })} class="article-link">
-        <h2 class="title">{getFullTitle(post)}</h2>
+        {#if headingLevel === 3}
+          <h3 class="title">{getFullTitle(post)}</h3>
+        {:else}
+          <h2 class="title">{getFullTitle(post)}</h2>
+        {/if}
 
         <p class="description">
-          {post.description}……
+          {post.description}&hellip;
         </p>
       </a>
 
-      <div class="meta-container bottom-meta-container for-small-screen">
-        <div class="date">{formatDate2JpStyle(post.metadata.publicatedAt)}</div>
-      </div>
-    </div>
+      <footer><TagList tags={post.metadata.tags} /></footer>
+    </article>
   {/each}
 
-  <div class="page-control">
-    <div class="page-button">
-      {#if currentPageNumber === 2}
-        {#if tag}
-          <a href={resolve('/tag/[tag=tag]', { tag })} class="pointer"> &lt; prev </a>
-        {:else}
-          <a href={resolve('/')} class="pointer"> &lt; prev </a>
+  {#if totalNumberOfPages > 1}
+    <nav class="page-control" aria-label="記事一覧のページ">
+      <div class="page-button">
+        {#if currentPageNumber === 2}
+          {#if tag}
+            <a href={resolve('/tag/[tag=tag]', { tag })} rel="prev">&#8592; 前へ</a>
+          {:else}
+            <a href={resolve('/')} rel="prev">&#8592; 前へ</a>
+          {/if}
+        {:else if currentPageNumber > 2}
+          {#if tag}
+            <a
+              href={resolve(`/tag/${tag}?p=${currentPageNumber - 1}` as `/tag/${string}?${string}`)}
+              rel="prev"
+            >
+              &#8592; 前へ
+            </a>
+          {:else}
+            <a href={resolve(`/?p=${currentPageNumber - 1}` as `/?${string}`)} rel="prev">
+              &#8592; 前へ
+            </a>
+          {/if}
         {/if}
-      {:else if currentPageNumber > 2}
-        {#if tag}
-          <a
-            href={resolve(`/tag/${tag}?p=${currentPageNumber - 1}` as `/tag/${string}?${string}`)}
-            class="pointer"
-          >
-            &lt; prev
-          </a>
-        {:else}
-          <a href={resolve(`/?p=${currentPageNumber - 1}` as `/?${string}`)} class="pointer">
-            &lt; prev
-          </a>
+      </div>
+      <p class="page-number" aria-current="page">
+        <span class="sr-only">ページ</span>
+        {currentPageNumber} / {totalNumberOfPages}
+      </p>
+      <div class="page-button right">
+        {#if currentPageNumber < totalNumberOfPages}
+          {#if tag}
+            <a
+              href={resolve(`/tag/${tag}?p=${currentPageNumber + 1}` as `/tag/${string}?${string}`)}
+              rel="next"
+            >
+              次へ &#8594;
+            </a>
+          {:else}
+            <a href={resolve(`/?p=${currentPageNumber + 1}` as `/?${string}`)} rel="next">
+              次へ &#8594;
+            </a>
+          {/if}
         {/if}
-      {/if}
-    </div>
-    <div class="page-number">
-      {currentPageNumber} / {totalNumberOfPages}
-    </div>
-    <div class="page-button right">
-      {#if currentPageNumber < totalNumberOfPages}
-        {#if tag}
-          <a
-            href={resolve(`/tag/${tag}?p=${currentPageNumber + 1}` as `/tag/${string}?${string}`)}
-            class="pointer"
-          >
-            next &gt;
-          </a>
-        {:else}
-          <a href={resolve(`/?p=${currentPageNumber + 1}` as `/?${string}`)} class="pointer">
-            next &gt;
-          </a>
-        {/if}
-      {/if}
-    </div>
-  </div>
-</main>
+      </div>
+    </nav>
+  {/if}
+</div>
 
 <style>
-  @media (max-width: 576px) {
-    .for-large-screen {
-      display: none !important;
-    }
-  }
-  @media (min-width: 577px) {
-    .for-small-screen {
-      height: 0;
-      display: none !important;
-    }
-  }
-
   .article-list {
-    margin: calc(var(--spacing-unit) * 10) 0;
+    border-top: 1px solid var(--color-border);
   }
 
   .article {
-    display: flex;
-    flex-direction: column;
-    margin: calc(var(--spacing-unit) * 6) 0;
-  }
-  .article:not(.article:first-of-type)::before {
-    display: block;
-    box-sizing: content-box;
-    width: 80%;
-    height: calc(
-      var(--spacing-unit) * 6 + 1em
-    ); /* .article:bottom-margin + p:margin-block-end - .article:gap */
-    content: '';
-    margin: 0 auto;
-    border-top: solid 1px var(--color-text-primary);
+    border-bottom: 1px solid var(--color-border);
+    padding: calc(var(--spacing-unit) * 8) 0;
   }
 
   .article-link {
     display: block;
     font-family: var(--serif);
-    transition: background-color 0.3s;
+    padding: calc(var(--spacing-unit) * 5) 0;
   }
-  .article-link:hover {
-    background-color: var(--color-background-secondary);
+
+  .article-link:hover,
+  .article-link:focus-visible {
     text-decoration: none;
   }
-  .article-link h2 {
-    margin: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 4);
+
+  .article-link:hover .title,
+  .article-link:focus-visible .title {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.18em;
   }
+
+  .title {
+    margin: 0;
+    font-size: 1.65rem;
+    font-weight: 500;
+    line-height: 1.5;
+  }
+
   .description {
-    margin: calc(var(--spacing-unit) * 4);
-    margin-top: 0;
+    margin: calc(var(--spacing-unit) * 4) 0 0;
     -webkit-box-orient: vertical;
-
-    font-size: 0.95em;
-    text-align: justify;
-    line-height: 1.75;
-    letter-spacing: 0.04em;
-
+    color: var(--color-text-secondary);
+    font-size: 0.95rem;
+    text-align: left;
+    line-height: 1.8;
+    letter-spacing: 0;
     line-clamp: 3;
     -webkit-line-clamp: 3;
     display: -webkit-box;
     overflow: hidden;
   }
 
-  @media (max-width: 576px) {
-    h2 {
-      font-size: 1.5rem;
-    }
-  }
-
   .meta-container {
     display: flex;
     justify-content: space-between;
-    padding: 0 calc(var(--spacing-unit) * 4);
-    font-size: 0.85em;
+    flex-wrap: wrap;
+    gap: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 5);
+    font-family: var(--display-font);
+    font-size: 0.72rem;
     color: var(--color-text-secondary);
   }
-  .bottom-meta-container {
-    flex-direction: row-reverse;
-  }
 
-  @media (max-width: 576px) {
-    .meta-container {
-      padding: 0;
-    }
-    .article-link h2 {
-      margin: calc(var(--spacing-unit) * 2) 0;
-    }
-    .description {
-      margin-left: 0;
-      line-clamp: 5;
-      -webkit-line-clamp: 5;
-    }
+  footer {
+    color: var(--color-text-secondary);
+    font-size: 0.76rem;
   }
 
   .page-control {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    width: 100%;
-    margin: 0 auto;
-    margin-top: calc(var(--spacing-unit) * 4);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 5);
+    margin-top: calc(var(--spacing-unit) * 12);
+    font-family: var(--display-font);
+    font-size: 0.8rem;
   }
+
   .page-number {
-    margin: 0 calc(var(--spacing-unit) * 4);
-    font-size: 110%;
+    margin: 0;
+    color: var(--color-text-secondary);
   }
-  @media (max-width: 576px) {
-    .page-control {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      width: 100%;
-      margin: 0 auto;
-    }
-    .page-number {
-      margin: 0;
-    }
-  }
+
   .page-button {
-    flex-basis: 4rem;
-    font-size: 110%;
-    color: var(--color-text-primary);
+    min-width: 0;
   }
+
+  .page-button a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    border-bottom: 1px solid currentColor;
+  }
+
   .right {
     text-align: right;
   }
-  .pointer {
-    cursor: pointer;
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
-  .pointer:hover {
-    text-decoration: underline;
+
+  @media (max-width: 576px) {
+    .article {
+      padding: calc(var(--spacing-unit) * 7) 0;
+    }
+
+    .title {
+      font-size: 1.35rem;
+    }
+
+    .description {
+      line-clamp: 4;
+      -webkit-line-clamp: 4;
+    }
+
+    .page-control {
+      gap: calc(var(--spacing-unit) * 2);
+    }
   }
 </style>

--- a/src/lib/component/SearchablePostList.svelte
+++ b/src/lib/component/SearchablePostList.svelte
@@ -23,8 +23,9 @@
 </script>
 
 <section class="post-list-header">
+  <p class="section-label">PROGRAM NOTES</p>
   <div class="heading-group">
-    <h2>{heading}</h2>
+    <h1>{heading}</h1>
     {#if summary}
       <p class="summary">{summary}</p>
     {/if}
@@ -35,23 +36,31 @@
 
 <style>
   .post-list-header {
-    display: flex;
-    justify-content: space-between;
-    gap: calc(var(--spacing-unit) * 5);
-    align-items: flex-start;
+    padding: clamp(36px, 7vw, 88px) 0 clamp(32px, 6vw, 72px);
   }
 
   .heading-group {
     min-width: 0;
     display: flex;
-    flex-direction: column;
-    gap: calc(var(--spacing-unit) * 1);
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: calc(var(--spacing-unit) * 3) calc(var(--spacing-unit) * 8);
+    align-items: baseline;
   }
 
-  h2 {
+  .section-label {
+    margin: 0 0 calc(var(--spacing-unit) * 5);
+    color: var(--color-text-secondary);
+    font-family: var(--display-font);
+    font-size: 0.72rem;
+  }
+
+  h1 {
     margin: 0;
     font-family: var(--serif);
-    font-size: 2rem;
+    font-size: 2.4rem;
+    font-weight: 500;
+    line-height: 1.35;
   }
 
   .summary {
@@ -59,13 +68,9 @@
     color: var(--color-text-secondary);
   }
 
-  @media (max-width: 576px) {
-    .post-list-header {
-      gap: calc(var(--spacing-unit) * 3);
-    }
-
-    h2 {
-      font-size: 1.7rem;
+  @media (max-width: 600px) {
+    h1 {
+      font-size: 1.8rem;
     }
   }
 </style>

--- a/src/lib/component/TagList.svelte
+++ b/src/lib/component/TagList.svelte
@@ -23,25 +23,41 @@
 ```
 -->
 
-<div class="tag">
+<ul class="tag" aria-label="記事のタグ">
   {#each tags as tag (tag)}
-    <div class="tag-item">
+    <li class="tag-item">
       <a href={resolve('/tag/[tag=tag]', { tag })}><span class="sharp">#&thinsp;</span>{tag}</a>
-    </div>
+    </li>
   {/each}
-</div>
+</ul>
 
 <style>
   .tag {
     display: flex;
-    flex-direction: row;
     flex-wrap: wrap;
+    gap: calc(var(--spacing-unit) * 1) calc(var(--spacing-unit) * 5);
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
+
   .tag-item {
-    display: block;
-    margin-right: 1em;
+    display: flex;
   }
+
+  a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 32px;
+    border-bottom: 1px solid transparent;
+  }
+
+  a:hover {
+    border-color: currentColor;
+    text-decoration: none;
+  }
+
   .sharp {
-    font-size: 95%;
+    color: var(--color-text-secondary);
   }
 </style>

--- a/src/lib/component/archive/ComposerDirectory.svelte
+++ b/src/lib/component/archive/ComposerDirectory.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import type { ComposerDirectoryGroup } from '$lib/posts/directory';
+  import type { Tag } from '$lib/posts/tags';
+
+  interface Props {
+    composers: ComposerDirectoryGroup[];
+  }
+
+  let { composers }: Props = $props();
+</script>
+
+<div class="composer-directory">
+  {#each composers as composer (composer.slug)}
+    <section class="composer-row" aria-labelledby={`composer-${composer.slug}`}>
+      <div class="composer-heading">
+        <p class="article-count">{composer.posts.length} ARTICLES</p>
+        <h3 id={`composer-${composer.slug}`}>
+          <a href={resolve('/tag/[tag=tag]', { tag: composer.shortName as Tag })}>
+            {composer.shortName}
+          </a>
+        </h3>
+        <p class="full-name">{composer.fullName}</p>
+        {#if Number.isFinite(composer.yearOfBirth)}
+          <p class="lifespan">
+            {composer.yearOfBirth}&ndash;{composer.yearOfDeath ?? ''}
+          </p>
+        {/if}
+      </div>
+
+      <ul class="note-list">
+        {#each composer.posts as post (post.slug)}
+          <li>
+            <a href={resolve('/post/[slug]', { slug: post.slug })}>
+              <span class="concert-title">{post.concertTitle}</span>
+              <span class="post-title">{post.title}</span>
+              <span class="arrow" aria-hidden="true">&#8594;</span>
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .composer-directory {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: clamp(32px, 7vw, 88px);
+    border-top: 1px solid var(--color-border);
+  }
+
+  .composer-row {
+    min-width: 0;
+    border-bottom: 1px solid var(--color-border);
+    padding: calc(var(--spacing-unit) * 10) 0 calc(var(--spacing-unit) * 12);
+  }
+
+  .composer-heading {
+    min-height: 9.5rem;
+  }
+
+  .article-count,
+  .full-name,
+  .lifespan {
+    margin: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .article-count {
+    margin-bottom: calc(var(--spacing-unit) * 3);
+    font-family: var(--display-font);
+    font-size: 0.7rem;
+  }
+
+  h3 {
+    margin: 0 0 calc(var(--spacing-unit) * 2);
+    font-family: var(--serif);
+    font-size: 1.55rem;
+    font-weight: 500;
+    line-height: 1.4;
+  }
+
+  h3 a {
+    border-bottom: 1px solid transparent;
+  }
+
+  h3 a:hover {
+    border-color: currentColor;
+    text-decoration: none;
+  }
+
+  .full-name,
+  .lifespan {
+    font-size: 0.78rem;
+    line-height: 1.6;
+  }
+
+  .note-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .note-list li {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .note-list a {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 1.25rem;
+    gap: calc(var(--spacing-unit) * 3);
+    min-height: 44px;
+    padding: calc(var(--spacing-unit) * 3) 0;
+    align-items: center;
+  }
+
+  .concert-title,
+  .post-title {
+    grid-column: 1;
+  }
+
+  .concert-title {
+    color: var(--color-text-secondary);
+    font-size: 0.7rem;
+  }
+
+  .post-title {
+    font-family: var(--serif);
+    line-height: 1.55;
+  }
+
+  .arrow {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    color: var(--color-text-secondary);
+    justify-self: end;
+  }
+
+  @media (max-width: 760px) {
+    .composer-directory {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .composer-heading {
+      min-height: 0;
+      margin-bottom: calc(var(--spacing-unit) * 7);
+    }
+
+    .composer-row {
+      padding-top: calc(var(--spacing-unit) * 9);
+    }
+  }
+</style>

--- a/src/lib/component/archive/ConcertDirectory.svelte
+++ b/src/lib/component/archive/ConcertDirectory.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import type { ConcertDirectoryGroup } from '$lib/posts/directory';
+  import { formatDate2JpStyle } from '$lib/util';
+  import Flyer from '../Flyer.svelte';
+
+  interface Props {
+    concerts: ConcertDirectoryGroup[];
+  }
+
+  let { concerts }: Props = $props();
+</script>
+
+<div class="concert-directory">
+  {#each concerts as concert (concert.slug)}
+    <section class="concert-row" aria-labelledby={`concert-${concert.slug}`}>
+      <div class="concert-copy">
+        <div class="concert-meta">
+          <time datetime={concert.date}>{formatDate2JpStyle(concert.date)}</time>
+          <span>{concert.posts.length} ARTICLES</span>
+        </div>
+
+        <h3 id={`concert-${concert.slug}`}>
+          <a href={concert.url} rel="external">{concert.title}</a>
+        </h3>
+
+        <ul class="note-list">
+          {#each concert.posts as post (post.slug)}
+            <li>
+              <a href={resolve('/post/[slug]', { slug: post.slug })}>
+                <span>{post.title}</span>
+                <span class="arrow" aria-hidden="true">&#8594;</span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </div>
+
+      <a
+        class="flyer-link"
+        href={concert.url}
+        rel="external"
+        aria-label={`${concert.title}の演奏会情報`}
+      >
+        <Flyer src={concert.flyer} alt={`${concert.title}のフライヤー`} />
+      </a>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .concert-directory {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .concert-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(180px, 280px);
+    gap: clamp(28px, 7vw, 88px);
+    align-items: start;
+    border-bottom: 1px solid var(--color-border);
+    padding: clamp(32px, 6vw, 72px) 0;
+  }
+
+  .concert-copy {
+    min-width: 0;
+  }
+
+  .concert-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--spacing-unit) * 3) calc(var(--spacing-unit) * 6);
+    justify-content: space-between;
+    margin-bottom: calc(var(--spacing-unit) * 4);
+    color: var(--color-text-secondary);
+    font-family: var(--display-font);
+    font-size: 0.72rem;
+  }
+
+  h3 {
+    margin: 0 0 calc(var(--spacing-unit) * 8);
+    font-size: 1.85rem;
+    font-weight: 500;
+    line-height: 1.35;
+  }
+
+  h3 a {
+    border-bottom: 1px solid transparent;
+  }
+
+  h3 a:hover {
+    border-color: currentColor;
+    text-decoration: none;
+  }
+
+  .note-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .note-list li {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .note-list li:last-child {
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .note-list a {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 1.5rem;
+    gap: calc(var(--spacing-unit) * 3);
+    align-items: center;
+    min-height: 44px;
+    padding: calc(var(--spacing-unit) * 3) 0;
+    font-family: var(--serif);
+    line-height: 1.55;
+  }
+
+  .note-list a:hover {
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.2em;
+  }
+
+  .arrow {
+    justify-self: end;
+    color: var(--color-text-secondary);
+    font-family: var(--display-font);
+  }
+
+  .flyer-link {
+    display: block;
+    aspect-ratio: 1 / 1.4142;
+    border: 0;
+    line-height: 0;
+  }
+
+  .flyer-link :global(img) {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: none;
+    object-fit: contain;
+  }
+
+  @media (max-width: 720px) {
+    .concert-row {
+      grid-template-columns: minmax(0, 1fr) minmax(110px, 35vw);
+      gap: calc(var(--spacing-unit) * 5);
+    }
+
+    .concert-meta {
+      flex-direction: column;
+      gap: calc(var(--spacing-unit) * 1);
+    }
+
+    h3 {
+      margin-bottom: calc(var(--spacing-unit) * 5);
+      font-size: 1.25rem;
+    }
+
+    .note-list a {
+      font-size: 0.85rem;
+    }
+  }
+
+  @media (max-width: 440px) {
+    .concert-row {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .flyer-link {
+      width: min(68vw, 250px);
+      justify-self: center;
+    }
+  }
+</style>

--- a/src/lib/component/archive/FeaturedCollection.svelte
+++ b/src/lib/component/archive/FeaturedCollection.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { getFullTitle, type PostListItem } from '$lib/posts';
+  import type { ConcertDirectoryGroup } from '$lib/posts/directory';
+  import { formatDate2JpStyle } from '$lib/util';
+  import Flyer from '../Flyer.svelte';
+
+  interface Props {
+    concert: ConcertDirectoryGroup;
+    posts: PostListItem[];
+  }
+
+  let { concert, posts }: Props = $props();
+</script>
+
+<section class="featured-collection" aria-labelledby="featured-collection-title">
+  <div class="collection-copy">
+    <p class="section-label">LATEST COLLECTION</p>
+    <div class="collection-heading">
+      <h2 id="featured-collection-title">{concert.title}演奏会</h2>
+      <time datetime={concert.date}>{formatDate2JpStyle(concert.date)}</time>
+    </div>
+
+    <ol class="program-list">
+      {#each posts as post, index (post.slug)}
+        <li>
+          <a href={resolve('/post/[slug]', { slug: post.slug })}>
+            <span class="program-number" aria-hidden="true">
+              {String(index + 1).padStart(2, '0')}
+            </span>
+            <span>{getFullTitle(post)}</span>
+            <span class="arrow" aria-hidden="true">&#8594;</span>
+          </a>
+        </li>
+      {/each}
+    </ol>
+
+    <a class="concert-link" href={concert.url} rel="external">
+      演奏会情報
+      <span aria-hidden="true">&#8599;</span>
+    </a>
+  </div>
+
+  <a
+    class="flyer-link"
+    href={concert.url}
+    rel="external"
+    aria-label={`${concert.title}の演奏会情報`}
+  >
+    <Flyer src={concert.flyer} alt={`${concert.title}のフライヤー`} loading="eager" />
+  </a>
+</section>
+
+<style>
+  .featured-collection {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(210px, 300px);
+    gap: clamp(32px, 7vw, 88px);
+    align-items: start;
+    border-top: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    padding: clamp(32px, 6vw, 72px) 0;
+  }
+
+  .collection-copy {
+    min-width: 0;
+  }
+
+  .section-label {
+    margin: 0 0 calc(var(--spacing-unit) * 6);
+    font-family: var(--display-font);
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+  }
+
+  .collection-heading {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: calc(var(--spacing-unit) * 3) calc(var(--spacing-unit) * 6);
+    align-items: baseline;
+    margin-bottom: calc(var(--spacing-unit) * 8);
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 2.25rem;
+    font-weight: 500;
+  }
+
+  time {
+    color: var(--color-text-secondary);
+    font-size: 0.82rem;
+  }
+
+  .program-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .program-list li {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .program-list li:last-child {
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .program-list a {
+    display: grid;
+    grid-template-columns: 2rem minmax(0, 1fr) 1.5rem;
+    gap: calc(var(--spacing-unit) * 3);
+    align-items: baseline;
+    min-height: 44px;
+    padding: calc(var(--spacing-unit) * 4) 0;
+    font-family: var(--serif);
+    line-height: 1.55;
+    transition:
+      color 180ms ease,
+      padding 180ms ease;
+  }
+
+  .program-list a:hover {
+    padding-left: calc(var(--spacing-unit) * 2);
+    text-decoration: none;
+  }
+
+  .program-number,
+  .arrow {
+    font-family: var(--display-font);
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
+  }
+
+  .arrow {
+    justify-self: end;
+  }
+
+  .concert-link {
+    display: inline-flex;
+    gap: calc(var(--spacing-unit) * 2);
+    align-items: center;
+    min-height: 44px;
+    margin-top: calc(var(--spacing-unit) * 6);
+    border-bottom: 1px solid currentColor;
+    font-size: 0.85rem;
+  }
+
+  .flyer-link {
+    display: block;
+    aspect-ratio: 1 / 1.4142;
+    border: 0;
+    line-height: 0;
+  }
+
+  .flyer-link :global(img) {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: none;
+    object-fit: contain;
+  }
+
+  @media (max-width: 680px) {
+    .featured-collection {
+      grid-template-columns: minmax(0, 1fr);
+      gap: calc(var(--spacing-unit) * 10);
+    }
+
+    .flyer-link {
+      width: min(72vw, 300px);
+      justify-self: center;
+    }
+
+    h2 {
+      font-size: 1.5rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .program-list a {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/component/archive/UpcomingConcert.svelte
+++ b/src/lib/component/archive/UpcomingConcert.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import { formatDate2JpStyle } from '$lib/util';
+  import Flyer from '../Flyer.svelte';
+
+  interface Props {
+    concert: {
+      title: string;
+      date: string;
+      url: string;
+      flyer: string;
+    };
+  }
+
+  let { concert }: Props = $props();
+</script>
+
+<aside class="upcoming-concert" aria-labelledby="upcoming-concert-title">
+  <div class="concert-details">
+    <p class="section-label">NEXT CONCERT</p>
+    <h2 id="upcoming-concert-title">{concert.title}演奏会</h2>
+    <time datetime={concert.date}>{formatDate2JpStyle(concert.date)}</time>
+    <a href={concert.url} rel="external">
+      演奏会情報
+      <span aria-hidden="true">&#8599;</span>
+    </a>
+  </div>
+
+  <a
+    class="flyer-link"
+    href={concert.url}
+    rel="external"
+    aria-label={`${concert.title}演奏会の情報`}
+  >
+    <Flyer src={concert.flyer} alt={`${concert.title}演奏会のフライヤー`} />
+  </a>
+</aside>
+
+<style>
+  .upcoming-concert {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(110px, 180px);
+    gap: calc(var(--spacing-unit) * 10);
+    align-items: center;
+    margin-top: clamp(72px, 11vw, 136px);
+    border-top: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    padding: calc(var(--spacing-unit) * 10) 0;
+  }
+
+  .concert-details {
+    min-width: 0;
+  }
+
+  .section-label {
+    margin: 0 0 calc(var(--spacing-unit) * 4);
+    color: var(--color-text-secondary);
+    font-family: var(--display-font);
+    font-size: 0.72rem;
+  }
+
+  h2 {
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 1.65rem;
+    font-weight: 500;
+    line-height: 1.5;
+  }
+
+  time {
+    display: block;
+    margin-top: calc(var(--spacing-unit) * 2);
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+  }
+
+  .concert-details > a {
+    display: inline-flex;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 2);
+    min-height: 44px;
+    margin-top: calc(var(--spacing-unit) * 5);
+    border-bottom: 1px solid currentColor;
+    font-size: 0.8rem;
+  }
+
+  .flyer-link {
+    display: block;
+    aspect-ratio: 1 / 1.4142;
+    border: 0;
+    line-height: 0;
+  }
+
+  .flyer-link :global(img) {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: none;
+  }
+
+  @media (max-width: 520px) {
+    .upcoming-concert {
+      grid-template-columns: minmax(0, 1fr) 96px;
+      gap: calc(var(--spacing-unit) * 5);
+    }
+
+    h2 {
+      font-size: 1.25rem;
+    }
+  }
+</style>

--- a/src/lib/component/post/Author.svelte
+++ b/src/lib/component/post/Author.svelte
@@ -6,7 +6,7 @@
   let { children }: Props = $props();
 </script>
 
-<p>
+<p class="post-author">
   （{@render children?.()}）
 </p>
 
@@ -23,8 +23,13 @@
 
 <style>
   p {
-    margin-bottom: calc(var(--spacing-unit) * 8);
+    margin: calc(var(--spacing-unit) * 10) 0 calc(var(--spacing-unit) * 8);
+    color: var(--color-text-secondary);
     text-align: right !important;
-    font-size: 0.85em;
+    font-family: var(--sans-serif) !important;
+    font-size: 0.8em;
+    line-height: 1.6 !important;
+    letter-spacing: 0;
+    text-indent: 0 !important;
   }
 </style>

--- a/src/lib/component/post/Figure.svelte
+++ b/src/lib/component/post/Figure.svelte
@@ -2,13 +2,15 @@
   interface Props {
     /** 表示する画像 */
     src: string;
+    /** 画像の代替テキスト。装飾・譜例画像では空文字列のまま利用できる。 */
+    alt?: string;
     /** キャプション */
     caption?: string | string[];
     /** 全体の最大高さ(px単位、オプション) */
     maxHeightPx?: number | undefined;
   }
 
-  let { src, caption = undefined, maxHeightPx = undefined }: Props = $props();
+  let { src, alt = '', caption = undefined, maxHeightPx = undefined }: Props = $props();
 
   const maxHeightStyle = $derived(
     maxHeightPx !== undefined ? `--max-height-px: ${maxHeightPx}px;` : ''
@@ -28,7 +30,7 @@
 -->
 
 <figure style={maxHeightStyle}>
-  <img {src} alt="" class="image" />
+  <img {src} {alt} class="image" loading="lazy" decoding="async" />
   {#if caption}
     <figcaption>
       {#if typeof caption === 'string'}
@@ -57,7 +59,11 @@
     max-width: 100%;
   }
   figcaption {
+    color: var(--color-text-secondary);
+    font-family: var(--sans-serif) !important;
     font-size: 0.85em;
+    line-height: 1.6;
+    letter-spacing: 0;
     text-align: center;
   }
 </style>

--- a/src/lib/component/post/Footnote.svelte
+++ b/src/lib/component/post/Footnote.svelte
@@ -24,6 +24,9 @@
   section {
     margin-top: calc(var(--spacing-unit) * 12);
     margin-bottom: calc(var(--spacing-unit) * 12);
+    padding-top: calc(var(--spacing-unit) * 4);
+    border-top: 1px solid var(--color-border);
+    color: var(--color-text-secondary);
     font-size: 0.85em;
     text-indent: 0;
   }

--- a/src/lib/component/post/MusicalNotation.svelte
+++ b/src/lib/component/post/MusicalNotation.svelte
@@ -39,8 +39,8 @@ Noto Musicフォントを使用。
 <style>
   span {
     display: inline-block;
-    margin: 0 5px;
-    transform: translateY(8px);
+    margin: 0 0.2em;
+    transform: translateY(0.22em);
 
     font-family: 'Noto Music', serif !important;
     font-weight: 400;
@@ -49,5 +49,6 @@ Noto Musicフォントを使用。
     font-size: 1.6em;
     line-height: 0;
     text-indent: 0;
+    vertical-align: baseline;
   }
 </style>

--- a/src/lib/component/post/Reference.svelte
+++ b/src/lib/component/post/Reference.svelte
@@ -20,16 +20,24 @@
 ```
 -->
 
-<h3>参考文献</h3>
+<section class="references">
+  <h3>参考文献</h3>
 
-<ol>
-  {@render children?.()}
-</ol>
+  <ol>
+    {@render children?.()}
+  </ol>
+</section>
 
 <style>
   ol {
-    margin: 0 0 calc(var(--spacing-unit) * 8) 0;
+    margin: 0 0 calc(var(--spacing-unit) * 8);
+    padding-inline-start: 1.5em;
+    color: var(--color-text-secondary);
     font-size: 0.85em;
-    list-style-type: '・';
+    line-height: 1.75;
+  }
+
+  ol :global(li)::marker {
+    font-family: var(--sans-serif);
   }
 </style>

--- a/src/lib/component/post/Spacer.svelte
+++ b/src/lib/component/post/Spacer.svelte
@@ -11,7 +11,7 @@
 ```
 -->
 
-<div></div>
+<div aria-hidden="true"></div>
 
 <style>
   div {

--- a/src/lib/component/post/UrlLink.svelte
+++ b/src/lib/component/post/UrlLink.svelte
@@ -18,3 +18,11 @@
 -->
 
 <a href={url} rel="external">{url}</a>
+
+<style>
+  a {
+    overflow-wrap: anywhere;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.2em;
+  }
+</style>

--- a/src/lib/posts/composers.ts
+++ b/src/lib/posts/composers.ts
@@ -81,8 +81,8 @@ export const composers = {
   rStrauss: {
     shortName: 'R.シュトラウス',
     fullName: 'リヒャルト・シュトラウス',
-    yearOfBirth: 1756,
-    yearOfDeath: 1791
+    yearOfBirth: 1864,
+    yearOfDeath: 1949
   },
   mahler: {
     shortName: 'マーラー',
@@ -123,8 +123,8 @@ export const composers = {
   tchaikovsky: {
     shortName: 'チャイコフスキー',
     fullName: 'ピョートル・チャイコフスキー',
-    yearOfBirth: 1865,
-    yearOfDeath: 1957
+    yearOfBirth: 1840,
+    yearOfDeath: 1893
   },
   elgar: {
     shortName: 'エルガー',

--- a/src/lib/posts/concerts.ts
+++ b/src/lib/posts/concerts.ts
@@ -64,7 +64,7 @@ export const concerts = {
   },
   'regular-7': {
     title: '第7回定期',
-    date: '2022-04-08',
+    date: '2023-04-08',
     url: 'https://www.orch-canvas.tokyo/concerts/regular-7',
     flyer: regular7
   },

--- a/src/lib/posts/directory.ts
+++ b/src/lib/posts/directory.ts
@@ -1,0 +1,81 @@
+import { composers, type composerSlug } from './composers';
+import { concerts, type concertSlug } from './concerts';
+import { getFullTitle, getPublishedPostMetadata } from './index';
+
+export type ConcertDirectoryPost = {
+  slug: string;
+  title: string;
+  composerName?: string;
+};
+
+export type ConcertDirectoryGroup = {
+  slug: concertSlug;
+  title: string;
+  date: string;
+  url: string;
+  flyer: string;
+  posts: ConcertDirectoryPost[];
+};
+
+export type ComposerDirectoryPost = {
+  slug: string;
+  title: string;
+  concertTitle: string;
+};
+
+export type ComposerDirectoryGroup = {
+  slug: composerSlug;
+  shortName: string;
+  fullName: string;
+  yearOfBirth: number;
+  yearOfDeath?: number;
+  posts: ComposerDirectoryPost[];
+};
+
+/** Published program notes grouped by their source concert, newest concert first. */
+export const getConcertDirectoryGroups = (): ConcertDirectoryGroup[] => {
+  const publishedPosts = getPublishedPostMetadata();
+
+  return (Object.entries(concerts) as [concertSlug, (typeof concerts)[concertSlug]][])
+    .map(([slug, concert]) => ({
+      slug,
+      title: concert.title,
+      date: concert.date,
+      url: concert.url,
+      flyer: concert.flyer,
+      posts: publishedPosts
+        .filter((post) => post.metadata.concertSlug === slug)
+        .map((post) => ({
+          slug: post.slug,
+          title: getFullTitle(post),
+          composerName: post.metadata.composerSlug
+            ? composers[post.metadata.composerSlug].shortName
+            : undefined
+        }))
+    }))
+    .filter((concert) => concert.posts.length > 0)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+};
+
+/** Published program notes grouped by composer, ordered by Japanese display name. */
+export const getComposerDirectoryGroups = (): ComposerDirectoryGroup[] => {
+  const publishedPosts = getPublishedPostMetadata();
+
+  return (Object.entries(composers) as [composerSlug, (typeof composers)[composerSlug]][])
+    .map(([slug, composer]) => ({
+      slug,
+      shortName: composer.shortName,
+      fullName: composer.fullName,
+      yearOfBirth: composer.yearOfBirth,
+      ...('yearOfDeath' in composer ? { yearOfDeath: composer.yearOfDeath } : {}),
+      posts: publishedPosts
+        .filter((post) => post.metadata.tags.includes(composer.shortName))
+        .map((post) => ({
+          slug: post.slug,
+          title: post.metadata.title,
+          concertTitle: concerts[post.metadata.concertSlug].title
+        }))
+    }))
+    .filter((composer) => composer.posts.length > 0)
+    .sort((a, b) => a.shortName.localeCompare(b.shortName, 'ja'));
+};

--- a/src/lib/posts/index.ts
+++ b/src/lib/posts/index.ts
@@ -28,6 +28,8 @@ export type PostListItem = PostMetadata & {
 /** ポストオブジェクトの型 */
 export type Post = PostListItem & {
   default: Component;
+  hasAuthorCredit: boolean;
+  hasTableOfContents: boolean;
 };
 
 export type SearchablePost = PostListItem & {
@@ -110,10 +112,16 @@ const toPostListItem = async (post: InternalPost): Promise<PostListItem> => ({
   description: await getPostDescription(post)
 });
 
-const toPost = async (post: InternalPost): Promise<Post> => ({
-  ...(await toPostListItem(post)),
-  default: post.default
-});
+const toPost = async (post: InternalPost): Promise<Post> => {
+  const rawPost = await getRawPost(post);
+
+  return {
+    ...(await toPostListItem(post)),
+    default: post.default,
+    hasAuthorCredit: /<Author(?:\s|>)/.test(rawPost),
+    hasTableOfContents: /<(?:h[34]|Reference)(?:\s|>)/.test(rawPost)
+  };
+};
 
 /**
  * ポストを取得する
@@ -201,6 +209,49 @@ export const getAdjacentPostListItemsBySlug = async (
     prev: index === sortedPosts.length - 1 ? null : await toPostListItem(sortedPosts[index + 1]),
     next: index === 0 ? null : await toPostListItem(sortedPosts[index - 1])
   };
+};
+
+export type RelatedPostListItems = {
+  sameConcert: PostListItem[];
+  sameComposer: PostListItem[];
+};
+
+/**
+ * 記事と同じ演奏会、または同じ作曲家の曲目解説を取得する。
+ * 同じ演奏会の記事を優先し、作曲家の記事との重複は除外する。
+ */
+export const getRelatedPostListItemsBySlug = async (
+  slug: string,
+  sameComposerLimit = 3
+): Promise<RelatedPostListItems> => {
+  const currentPost = posts[slug];
+  if (currentPost === undefined || !currentPost.metadata.published) {
+    return { sameConcert: [], sameComposer: [] };
+  }
+
+  const otherPublishedPosts = getSortedPublishedInternalPosts().filter(
+    (post) => post.slug !== slug
+  );
+  const sameConcertPosts = otherPublishedPosts.filter(
+    (post) => post.metadata.concertSlug === currentPost.metadata.concertSlug
+  );
+  const sameComposerPosts =
+    currentPost.metadata.composerSlug === undefined
+      ? []
+      : otherPublishedPosts
+          .filter(
+            (post) =>
+              post.metadata.composerSlug === currentPost.metadata.composerSlug &&
+              post.metadata.concertSlug !== currentPost.metadata.concertSlug
+          )
+          .slice(0, sameComposerLimit);
+
+  const [sameConcert, sameComposer] = await Promise.all([
+    Promise.all(sameConcertPosts.map((post) => toPostListItem(post))),
+    Promise.all(sameComposerPosts.map((post) => toPostListItem(post)))
+  ]);
+
+  return { sameConcert, sameComposer };
 };
 
 /**

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -3,8 +3,15 @@
  * @param date 日付文字列
  * @returns e.g. 2222/2/2
  */
-export const formatDate2JpStyle = (date: string) =>
-  `${new Date(date).getFullYear()}/${new Date(date).getMonth() + 1}/${new Date(date).getDate()}`;
+export const formatDate2JpStyle = (date: string) => {
+  const calendarDate = /^(\d{4})-(\d{2})-(\d{2})(?:T|$)/.exec(date);
+  if (calendarDate) {
+    return `${Number(calendarDate[1])}/${Number(calendarDate[2])}/${Number(calendarDate[3])}`;
+  }
+
+  const parsedDate = new Date(date);
+  return `${parsedDate.getFullYear()}/${parsedDate.getMonth() + 1}/${parsedDate.getDate()}`;
+};
 
 /**
  * ポストの生テキストから検索用のプレーンテキストを生成する。

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -2,34 +2,51 @@
   import { page } from '$app/stores';
 </script>
 
-<div>
+<main>
   {#if $page.status === 404}
-    <h2>404: Not Found</h2>
+    <p class="section-label">ERROR</p>
+    <h1>404: Not Found</h1>
     {#if $page.error?.message}
       <p>{$page.error.message}</p>
     {:else}
       <p>お探しのページは見つかりませんでした。</p>
     {/if}
   {:else}
-    <h2>{$page.status}</h2>
+    <p class="section-label">ERROR</p>
+    <h1>{$page.status}</h1>
     {#if $page.error?.message}
       <p>{$page.error.message}</p>
     {/if}
   {/if}
-</div>
+</main>
 
 <style>
-  div {
+  main {
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: calc(var(--spacing-unit) * 28) 0;
+    justify-content: center;
+    min-height: 52vh;
+    padding: calc(var(--spacing-unit) * 16) 0;
+    text-align: center;
   }
-  h2 {
-    margin: calc(var(--spacing-unit) * 4) 0;
+
+  .section-label {
+    margin: 0 0 calc(var(--spacing-unit) * 4);
+    color: var(--color-text-secondary);
+    font-family: var(--display-font);
+    font-size: 0.72rem;
   }
+
+  h1 {
+    margin: 0 0 calc(var(--spacing-unit) * 5);
+    font-family: var(--display-font);
+    font-size: 2rem;
+    font-weight: 500;
+  }
+
   p {
     margin: 0;
-    text-indent: 0;
+    color: var(--color-text-secondary);
   }
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,247 +1,457 @@
 <script lang="ts">
+  import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import headerSmall from './header-small.svg';
   import headerLarge from './header-large.svg';
   import logo from './orchestra-canvas-tokyo.svg';
   import instagram from './sns-instagram.svg';
   import facebook from './sns-facebook.svg';
   import x from './sns-x.svg';
   import youtube from './sns-youtube.svg';
-  import { onMount } from 'svelte';
   import BlogSearch from '$lib/component/BlogSearch.svelte';
   import CookieConcent from '$lib/component/CookieConcent.svelte';
+
   interface Props {
     children?: import('svelte').Snippet;
   }
 
+  interface BrowseLink {
+    label: string;
+    view: 'latest' | 'concerts' | 'composers';
+  }
+
   let { children }: Props = $props();
 
-  onMount(() => {
-    // viewportが375px未満のとき、全体を縮小して表示する
-    const adjustViewport = () => {
-      const triggerWidth = 375;
-      const viewport = document.querySelector('meta[name="viewport"]');
-      if (viewport === null) return;
-      const value =
-        window.outerWidth < triggerWidth
-          ? `width=${triggerWidth}`
-          : 'width=device-width, initial-scale=1';
-      viewport.setAttribute('content', value);
-    };
-
-    /**
-     * 頻繁に呼び出されうる関数を、300msごとの実行に制限する
-     * @param func 呼び出される関数
-     */
-    const debounce = (func: () => void) => {
-      let timer: number;
-      return () => {
-        clearTimeout(timer);
-        timer = setTimeout(func, 300);
-      };
-    };
-
-    const debouncedFunction = debounce(adjustViewport);
-    window.addEventListener('resize', debouncedFunction, false);
-  });
+  const browseLinks: BrowseLink[] = [
+    { label: 'LATEST', view: 'latest' },
+    { label: 'CONCERTS', view: 'concerts' },
+    { label: 'COMPOSERS', view: 'composers' }
+  ];
+  const rootPath = resolve('/');
+  const activeView = $derived(
+    page.url.pathname === rootPath ? (page.url.searchParams.get('view') ?? 'latest') : null
+  );
 </script>
 
 <svelte:head>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
   <link
-    href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400&family=Noto+Serif+JP:wght@700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;600;700&display=swap"
     rel="stylesheet"
   />
-
   <link
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/yakuhanjp@4.1.1/dist/css/yakuhanmp_s.css"
   />
 </svelte:head>
 
-<header>
-  <!-- header -->
-  <a href={resolve('/')} id="page_top">
-    <h1>
-      <div class="logo-container">
-        <picture>
-          <source srcset={headerSmall} media="(max-width: 576px)" />
-          <img class="logo-image" src={headerLarge} alt="Orchestra Canvas Tokyo Blog" />
-        </picture>
-      </div>
-    </h1>
-  </a>
-  <div class="header-search">
-    <BlogSearch />
+<a class="skip-link" href="#main-content">本文へ移動</a>
+
+<header class="site-header">
+  <div class="site-header__inner">
+    <a href={rootPath} class="blog-brand" aria-label="Orchestra Canvas Tokyo Blog ホーム">
+      <img src={headerLarge} alt="Orchestra Canvas Tokyo Blog" />
+    </a>
+
+    <nav class="browse-navigation" aria-label="ブログを閲覧">
+      <ul>
+        {#each browseLinks as item (item.view)}
+          <li>
+            <a
+              href={resolve(`/?view=${item.view}` as `/?${string}`)}
+              class:active={activeView === item.view}
+              aria-current={activeView === item.view ? 'page' : undefined}
+            >
+              {item.label}
+            </a>
+          </li>
+        {/each}
+        <li>
+          <a
+            class="oct-site-link"
+            href="https://www.orch-canvas.tokyo/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            OCT SITE <span aria-hidden="true">↗</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+
+    <div class="header-search">
+      <BlogSearch />
+    </div>
   </div>
 </header>
 
-{@render children?.()}
+<div id="main-content" class="site-content" tabindex="-1">
+  {@render children?.()}
+</div>
 
-<footer>
-  <div class="inline-logo-container">
-    <a href="https://www.orch-canvas.tokyo/">
-      &copy; <img
-        class="inline-logo"
-        width="199"
-        height="33.59"
-        src={logo}
-        alt="Orchestra Canvas Tokyo"
-      />
-    </a>
-  </div>
-  <div class="sns-icon-container">
-    <a href="https://www.instagram.com/orchestracanvastokyo/">
-      <img class="sns-icon" width="25.59" height="29.25" src={instagram} alt="Instagram" />
-    </a>
-    <a href="https://www.facebook.com/OrchestraCanvasTokyo">
-      <img class="sns-icon" width="25.59" height="29.59" src={facebook} alt="Facebook" />
-    </a>
-    <a href="https://x.com/Orch_canvas">
-      <img class="sns-icon" width="25.59" height="23" src={x} alt="X" />
-    </a>
-    <a href="https://www.youtube.com/channel/UCX2SZ5NViwsaOza3biDNjIw">
-      <img class="sns-icon" width="25.59" height="22.75" src={youtube} alt="YouTube" />
-    </a>
-  </div>
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__primary">
+      <a class="footer-brand" href="https://www.orch-canvas.tokyo/">
+        <span aria-hidden="true">&copy;</span>
+        <img width="199" height="34" src={logo} alt="Orchestra Canvas Tokyo" />
+      </a>
 
-  <CookieConcent />
+      <nav class="social-navigation" aria-label="ソーシャルメディア">
+        <a href="https://www.instagram.com/orchestracanvastokyo/" aria-label="Instagram">
+          <img width="24" height="24" src={instagram} alt="" />
+        </a>
+        <a href="https://www.facebook.com/OrchestraCanvasTokyo" aria-label="Facebook">
+          <img width="24" height="24" src={facebook} alt="" />
+        </a>
+        <a href="https://x.com/Orch_canvas" aria-label="X">
+          <img width="22" height="22" src={x} alt="" />
+        </a>
+        <a href="https://www.youtube.com/channel/UCX2SZ5NViwsaOza3biDNjIw" aria-label="YouTube">
+          <img width="25" height="22" src={youtube} alt="" />
+        </a>
+      </nav>
+    </div>
+
+    <CookieConcent />
+  </div>
 </footer>
 
 <style>
   :global(:root) {
+    color-scheme: dark;
     --spacing-unit: 4px;
-    --color-background: #fff;
-    --color-background-secondary: #eee;
-    --color-text-primary: #000;
-    --color-text-secondary: #5a5a5a;
-    --sans-serif: sans-serif;
+    --color-background: #0a0606;
+    --color-surface: #171313;
+    --color-surface-raised: #36312e;
+    --color-text-primary: #ffffff;
+    --color-text-secondary: #938b87;
+    --color-border: #57504c;
+    --color-inverse-background: #ffffff;
+    --color-inverse-text: #0a0606;
+    --sans-serif:
+      'Yu Gothic Medium', 'Yu Gothic', YuGothic, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans',
+      Meiryo, sans-serif;
+    --display-font: Futura, Avenir, 'Century Gothic', 'Helvetica Neue', Arial, sans-serif;
     --serif: YakuHanMPs, 'Noto Serif JP', 'Hiragino Mincho ProN', 'Yu Mincho', YuMincho, serif;
+    --content-max-width: 1280px;
+    --reading-max-width: 720px;
+
+    /* Compatibility for components being migrated to the shared surface tokens. */
+    --color-background-secondary: var(--color-surface-raised);
+  }
+
+  :global(*),
+  :global(*::before),
+  :global(*::after) {
+    box-sizing: border-box;
+    letter-spacing: 0;
   }
 
   :global(html) {
-    background-color: var(--color-background-secondary);
+    min-width: 320px;
+    min-height: 100%;
+    background: var(--color-background);
+    scroll-behavior: smooth;
   }
 
   :global(body) {
-    margin: 0 auto;
-    max-width: 1000px;
-    padding: calc(var(--spacing-unit) * 8);
+    min-width: 320px;
+    min-height: 100vh;
+    margin: 0;
+    overflow-wrap: anywhere;
+    background: var(--color-background);
+    color: var(--color-text-primary);
     font-family: var(--sans-serif);
+    font-size: 16px;
+    line-height: 1.7;
+    line-break: strict;
+    word-break: normal;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-
-    background-color: var(--color-background);
-    color: var(--color-text-primary);
-    line-height: 1.51;
-    font-size: 18px;
-
-    overflow-wrap: anywhere; /* 収まらない場合に折りかえす */
-    word-break: normal; /* 単語の分割はデフォルトに依存 */
-    line-break: strict; /* 禁則処理を厳格に適用 */
   }
 
-  @media (max-width: 576px) {
-    :global(body) {
-      padding: calc(var(--spacing-unit) * 6);
-      font-size: 16px;
-    }
-  }
-
-  :global(a, a:visited, a:active) {
+  :global(a) {
     color: inherit;
-    text-decoration: none;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.2em;
   }
 
-  :global(a:hover) {
-    text-decoration: underline;
+  :global(button),
+  :global(input),
+  :global(textarea),
+  :global(select) {
+    font: inherit;
   }
 
-  @media (max-width: 576px) {
-    :global(ul),
-    :global(ol) {
-      padding-inline-start: calc(var(--spacing-unit) * 5);
-    }
+  :global(img) {
+    max-width: 100%;
   }
 
-  header {
+  :global(:focus-visible) {
+    outline: 2px solid var(--color-text-primary);
+    outline-offset: 3px;
+  }
+
+  .skip-link {
+    position: fixed;
+    top: calc(var(--spacing-unit) * 3);
+    left: calc(var(--spacing-unit) * 3);
+    z-index: 100;
+    min-height: 44px;
+    padding: calc(var(--spacing-unit) * 2.5) calc(var(--spacing-unit) * 4);
+    transform: translateY(calc(-100% - var(--spacing-unit) * 4));
+    border: 1px solid var(--color-text-primary);
+    background: var(--color-inverse-background);
+    color: var(--color-inverse-text);
+  }
+
+  .skip-link:focus {
+    transform: translateY(0);
+  }
+
+  .site-header {
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .site-header__inner {
+    display: grid;
+    grid-template-columns: minmax(240px, 1fr) auto 44px;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 7);
+    width: min(100%, var(--content-max-width));
+    min-height: 96px;
+    margin: 0 auto;
+    padding: calc(var(--spacing-unit) * 5) calc(var(--spacing-unit) * 8);
+  }
+
+  .blog-brand {
+    display: inline-flex;
+    width: min(100%, 318px);
+    border: 0;
+  }
+
+  .blog-brand img {
+    display: block;
+    width: 100%;
+    height: auto;
+    filter: grayscale(1) brightness(0) invert(1);
+  }
+
+  .browse-navigation ul {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 6);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .browse-navigation a {
     position: relative;
-    /* header.margin-bottom = body.padding-top + h1.margin-top */
-    margin-bottom: calc(var(--spacing-unit) * 12 + 0.67em);
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    border: 0;
+    color: var(--color-text-secondary);
+    font-family: var(--display-font);
+    font-size: 0.75rem;
+    line-height: 1;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: color 160ms ease;
+  }
+
+  .browse-navigation a::after {
+    position: absolute;
+    right: 0;
+    bottom: 6px;
+    left: 0;
+    height: 1px;
+    content: '';
+    background: currentColor;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 160ms ease;
+  }
+
+  .browse-navigation a:hover,
+  .browse-navigation a.active {
+    color: var(--color-text-primary);
+  }
+
+  .browse-navigation a:hover::after,
+  .browse-navigation a.active::after {
+    transform: scaleX(1);
+  }
+
+  .oct-site-link span {
+    margin-left: calc(var(--spacing-unit) * 1.5);
+    font-size: 0.9em;
   }
 
   .header-search {
-    position: absolute;
-    top: calc(var(--spacing-unit) * 2);
-    right: 0;
+    display: flex;
+    justify-content: flex-end;
   }
 
-  .logo-container > picture {
-    aspect-ratio: 459.8 / 90;
-  }
-  .logo-image {
-    margin-bottom: -12.36px;
-    margin-left: 13px;
-    height: 90px;
-  }
-  @media (max-width: 576px) {
-    header {
-      /* header.margin-bottom = body.padding-top */
-      margin-bottom: calc(var(--spacing-unit) * 8);
-    }
-    .header-search {
-      top: 0;
-    }
-    .logo-container {
-      display: grid;
-      place-items: center;
-    }
-    .logo-container > picture {
-      aspect-ratio: 200 / 119.2;
-    }
-    .logo-image {
-      margin-bottom: -12.37px;
-      margin-left: 0;
-      width: 200px;
-      height: unset;
-    }
+  .site-content {
+    width: min(100%, var(--content-max-width));
+    min-height: 50vh;
+    margin: 0 auto;
+    padding-right: calc(var(--spacing-unit) * 8);
+    padding-left: calc(var(--spacing-unit) * 8);
   }
 
-  footer {
-    margin-top: calc(var(--spacing-unit) * 16);
-    margin-bottom: calc(var(--spacing-unit) * 8);
-    font-size: 14px;
+  .site-footer {
+    margin-top: calc(var(--spacing-unit) * 24);
+    border-top: 1px solid var(--color-border);
+  }
+
+  .site-footer__inner {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    gap: calc(var(--spacing-unit) * 4);
+    gap: calc(var(--spacing-unit) * 5);
+    width: min(100%, var(--content-max-width));
+    margin: 0 auto;
+    padding: calc(var(--spacing-unit) * 8);
   }
-  .inline-logo-container {
+
+  .site-footer__primary {
     display: flex;
-    align-items: center;
-  }
-  .inline-logo-container a {
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
-  }
-  .inline-logo-container a:hover {
-    text-decoration: none;
-  }
-  .sns-icon-container {
-    display: flex;
+    justify-content: space-between;
     align-items: center;
     gap: calc(var(--spacing-unit) * 8);
   }
-  .sns-icon {
-    margin-bottom: -5.13px;
-    width: 1.6rem;
+
+  .footer-brand {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    gap: calc(var(--spacing-unit) * 3);
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
+    text-decoration: none;
   }
 
-  @media (max-width: 300px) {
-    .inline-logo {
-      margin-left: 0;
+  .footer-brand img {
+    width: 185px;
+    height: auto;
+    filter: grayscale(1) brightness(0) invert(1);
+  }
+
+  .social-navigation {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 2);
+  }
+
+  .social-navigation a {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 44px;
+    height: 44px;
+    color: var(--color-text-secondary);
+    transition:
+      color 160ms ease,
+      background-color 160ms ease;
+  }
+
+  .social-navigation a:hover {
+    background: var(--color-surface-raised);
+    color: var(--color-text-primary);
+  }
+
+  .social-navigation img {
+    max-width: 24px;
+    max-height: 24px;
+    filter: grayscale(1) brightness(0) invert(1);
+  }
+
+  @media (max-width: 900px) {
+    .site-header__inner {
+      grid-template-areas:
+        'brand search'
+        'navigation navigation';
+      grid-template-columns: minmax(0, 1fr) 44px;
+      gap: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 4);
+      padding-top: calc(var(--spacing-unit) * 4);
+      padding-bottom: calc(var(--spacing-unit) * 3);
+    }
+
+    .blog-brand {
+      grid-area: brand;
+      width: min(100%, 280px);
+    }
+
+    .browse-navigation {
+      grid-area: navigation;
+    }
+
+    .header-search {
+      grid-area: search;
+    }
+
+    .browse-navigation ul {
+      justify-content: space-between;
+      gap: calc(var(--spacing-unit) * 3);
+    }
+  }
+
+  @media (max-width: 576px) {
+    .site-header__inner,
+    .site-content,
+    .site-footer__inner {
+      padding-right: calc(var(--spacing-unit) * 4);
+      padding-left: calc(var(--spacing-unit) * 4);
+    }
+
+    .site-header__inner {
+      min-height: 0;
+    }
+
+    .blog-brand {
+      width: min(100%, 224px);
+    }
+
+    .browse-navigation ul {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0 calc(var(--spacing-unit) * 3);
+    }
+
+    .browse-navigation li {
+      min-width: 0;
+    }
+
+    .browse-navigation a {
+      width: 100%;
+    }
+
+    .site-footer {
+      margin-top: calc(var(--spacing-unit) * 16);
+    }
+
+    .site-footer__primary {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: calc(var(--spacing-unit) * 3);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(html:focus-within) {
+      scroll-behavior: auto;
+    }
+
+    :global(*),
+    :global(*::before),
+    :global(*::after) {
+      scroll-behavior: auto !important;
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
     }
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import type { PageData } from './$types';
   import Meta from '$lib/component/Meta.svelte';
-  import SearchablePostList from '$lib/component/SearchablePostList.svelte';
+  import PostList from '$lib/component/PostList.svelte';
+  import FeaturedCollection from '$lib/component/archive/FeaturedCollection.svelte';
+  import ConcertDirectory from '$lib/component/archive/ConcertDirectory.svelte';
+  import ComposerDirectory from '$lib/component/archive/ComposerDirectory.svelte';
+  import UpcomingConcert from '$lib/component/archive/UpcomingConcert.svelte';
 
   interface Props {
     data: PageData;
@@ -12,9 +17,217 @@
 
 <Meta title="" canonical="/" />
 
-<SearchablePostList
-  heading="記事一覧"
-  posts={data.posts}
-  currentPageNumber={data.currentPageNumber}
-  totalNumberOfPages={data.totalNumberOfPages}
-/>
+<main class="archive-page">
+  <header class="archive-header">
+    <p class="organization-name">ORCHESTRA CANVAS TOKYO</p>
+    <div class="archive-title-group">
+      <h1>program notes</h1>
+      <div class="archive-summary">
+        <p>曲目解説アーカイブ</p>
+        <p>{data.totalNumberOfPosts} ARTICLES</p>
+      </div>
+    </div>
+  </header>
+
+  <nav class="browse-tabs" aria-label="曲目解説の表示方法">
+    <a
+      href={resolve('/')}
+      class:active={data.view === 'latest'}
+      aria-current={data.view === 'latest' ? 'page' : undefined}
+    >
+      LATEST
+    </a>
+    <a
+      href={resolve('/?view=concerts' as `/?${string}`)}
+      class:active={data.view === 'concerts'}
+      aria-current={data.view === 'concerts' ? 'page' : undefined}
+    >
+      CONCERTS
+    </a>
+    <a
+      href={resolve('/?view=composers' as `/?${string}`)}
+      class:active={data.view === 'composers'}
+      aria-current={data.view === 'composers' ? 'page' : undefined}
+    >
+      COMPOSERS
+    </a>
+  </nav>
+
+  {#if data.view === 'latest'}
+    {#if data.featuredCollection?.concert}
+      <FeaturedCollection
+        concert={data.featuredCollection.concert}
+        posts={data.featuredCollection.posts}
+      />
+    {/if}
+
+    <section class="recent-notes" aria-labelledby="recent-notes-title">
+      <div class="section-heading">
+        <p>RECENT NOTES</p>
+        <h2 id="recent-notes-title">
+          {data.currentPageNumber === 1 ? '新着記事' : `記事一覧 ${data.currentPageNumber}`}
+        </h2>
+      </div>
+      <PostList
+        posts={data.posts}
+        currentPageNumber={data.currentPageNumber}
+        totalNumberOfPages={data.totalNumberOfPages}
+        headingLevel={3}
+      />
+    </section>
+  {:else if data.view === 'concerts'}
+    <section class="directory-section" aria-labelledby="concert-directory-title">
+      <div class="section-heading">
+        <p>BY CONCERT</p>
+        <h2 id="concert-directory-title">演奏会別</h2>
+      </div>
+      <ConcertDirectory concerts={data.concertGroups} />
+    </section>
+  {:else}
+    <section class="directory-section" aria-labelledby="composer-directory-title">
+      <div class="section-heading">
+        <p>BY COMPOSER</p>
+        <h2 id="composer-directory-title">作曲家別</h2>
+      </div>
+      <ComposerDirectory composers={data.composerGroups} />
+    </section>
+  {/if}
+
+  {#if data.upcomingConcert}
+    <UpcomingConcert concert={data.upcomingConcert} />
+  {/if}
+</main>
+
+<style>
+  .archive-header {
+    padding: clamp(36px, 7vw, 88px) 0 clamp(40px, 8vw, 96px);
+  }
+
+  .organization-name,
+  .archive-summary,
+  .section-heading > p {
+    font-family: var(--display-font);
+    color: var(--color-text-secondary);
+  }
+
+  .organization-name {
+    margin: 0 0 calc(var(--spacing-unit) * 6);
+    font-size: 0.72rem;
+  }
+
+  .archive-title-group {
+    display: flex;
+    justify-content: space-between;
+    gap: calc(var(--spacing-unit) * 8);
+    align-items: flex-end;
+  }
+
+  h1 {
+    margin: 0;
+    font-family: var(--display-font);
+    font-size: 3rem;
+    font-weight: 500;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .archive-summary {
+    text-align: right;
+    font-size: 0.78rem;
+  }
+
+  .archive-summary p {
+    margin: 0;
+  }
+
+  .browse-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1px;
+    margin-bottom: clamp(40px, 7vw, 88px);
+    background: var(--color-border);
+    border: 1px solid var(--color-border);
+  }
+
+  .browse-tabs a {
+    display: grid;
+    place-items: center;
+    min-height: 48px;
+    padding: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 3);
+    background: var(--color-background);
+    font-family: var(--display-font);
+    font-size: 0.78rem;
+    transition:
+      background-color 180ms ease,
+      color 180ms ease;
+  }
+
+  .browse-tabs a:hover,
+  .browse-tabs a.active {
+    background: var(--color-text-primary);
+    color: var(--color-background);
+    text-decoration: none;
+  }
+
+  .recent-notes,
+  .directory-section {
+    margin-top: clamp(64px, 10vw, 120px);
+  }
+
+  .section-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: calc(var(--spacing-unit) * 6);
+    align-items: baseline;
+    margin-bottom: calc(var(--spacing-unit) * 8);
+  }
+
+  .section-heading > p {
+    margin: 0;
+    font-size: 0.72rem;
+  }
+
+  .section-heading h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+
+  @media (max-width: 600px) {
+    .archive-header {
+      padding-top: calc(var(--spacing-unit) * 10);
+    }
+
+    .archive-title-group {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: calc(var(--spacing-unit) * 6);
+    }
+
+    h1 {
+      font-size: 2.2rem;
+    }
+
+    .archive-summary {
+      display: flex;
+      flex-wrap: wrap;
+      gap: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 5);
+      text-align: left;
+    }
+
+    .browse-tabs a {
+      font-size: 0.67rem;
+    }
+
+    .section-heading {
+      flex-direction: column;
+      gap: calc(var(--spacing-unit) * 2);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .browse-tabs a {
+      transition: none;
+    }
+  }
+</style>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,13 +1,27 @@
 import { getPostCount, getPostListItems } from '$lib/posts';
+import { concerts } from '$lib/posts/concerts';
+import { getComposerDirectoryGroups, getConcertDirectoryGroups } from '$lib/posts/directory';
 import { PostCountInOnePage } from '$lib/util';
 import { error, redirect } from '@sveltejs/kit';
 
 import type { PageLoad } from './$types';
 
+const browseViews = ['latest', 'concerts', 'composers'] as const;
+type BrowseView = (typeof browseViews)[number];
+
 export const load: PageLoad = async ({ url }) => {
+  const rawView = url.searchParams.get('view');
+  const view: BrowseView = rawView === null ? 'latest' : (rawView as BrowseView);
+  if (!browseViews.includes(view)) error(404);
+
   // URLからpageNumberを取得
   const rawPageNumber = url.searchParams.get('p');
   let pageNumber: number;
+
+  if (view !== 'latest' && rawPageNumber !== null) {
+    url.searchParams.delete('p');
+    redirect(302, url.href);
+  }
 
   if (rawPageNumber === null) {
     pageNumber = 1; // パラメータがない場合は1ページ目想定
@@ -23,17 +37,53 @@ export const load: PageLoad = async ({ url }) => {
     }
   }
 
-  // ポストを取得する
   const totalNumberOfPosts = getPostCount();
   const totalNumberOfPages = Math.ceil(totalNumberOfPosts / PostCountInOnePage);
-  // インデックス範囲外には404を
   if (totalNumberOfPages < pageNumber) error(404);
 
+  const paginatedPosts =
+    view === 'latest'
+      ? await getPostListItems({
+          offset: PostCountInOnePage * (pageNumber - 1),
+          limit: PostCountInOnePage
+        })
+      : [];
+
+  const featuredConcertSlug =
+    pageNumber === 1 ? paginatedPosts[0]?.metadata.concertSlug : undefined;
+  const featuredPosts = featuredConcertSlug
+    ? paginatedPosts
+        .filter((post) => post.metadata.concertSlug === featuredConcertSlug)
+        .sort((a, b) => a.metadata.publicatedAt.localeCompare(b.metadata.publicatedAt))
+    : [];
+  const posts = featuredConcertSlug
+    ? paginatedPosts.filter((post) => post.metadata.concertSlug !== featuredConcertSlug)
+    : paginatedPosts;
+  const concertGroups = getConcertDirectoryGroups();
+  const todayInJapan = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).format(new Date());
+  const upcomingConcert = [...Object.values(concerts)]
+    .filter((concert) => concert.date >= todayInJapan)
+    .sort((a, b) => a.date.localeCompare(b.date))[0];
+
   return {
-    posts: await getPostListItems({
-      offset: PostCountInOnePage * (pageNumber - 1),
-      limit: PostCountInOnePage
-    }),
+    view,
+    posts,
+    featuredCollection:
+      featuredConcertSlug === undefined
+        ? null
+        : {
+            concert: concertGroups.find((concert) => concert.slug === featuredConcertSlug) ?? null,
+            posts: featuredPosts
+          },
+    concertGroups,
+    composerGroups: getComposerDirectoryGroups(),
+    upcomingConcert: upcomingConcert ?? null,
+    totalNumberOfPosts,
     currentPageNumber: pageNumber,
     totalNumberOfPages: totalNumberOfPages
   };

--- a/src/routes/cookie-policy/+page.svelte
+++ b/src/routes/cookie-policy/+page.svelte
@@ -4,149 +4,171 @@
 
 <Meta title="Cookieポリシー" canonical="/cookie-policy" />
 
-<h2>Cookieポリシー</h2>
+<main class="policy-page">
+  <header class="page-heading">
+    <p>POLICY</p>
+    <h1>Cookieポリシー</h1>
+  </header>
 
-<main>
-  <p>
-    Orchestra Canvas
-    Tokyo（以下、「当団」といいます。）は、お客様のウェブサイト利用状況を分析し、または個々のお客様に対してカスタマイズされたサービスを提供する等の目的のため、クッキーを使用して一定の情報を収集します。
-  </p>
+  <article>
+    <p>
+      Orchestra Canvas
+      Tokyo（以下、「当団」といいます。）は、お客様のウェブサイト利用状況を分析し、または個々のお客様に対してカスタマイズされたサービスを提供する等の目的のため、クッキーを使用して一定の情報を収集します。
+    </p>
 
-  <h3>1. クッキーについて</h3>
+    <h2>1. クッキーについて</h2>
 
-  <p>
-    クッキーとはお客様のウェブサイト閲覧情報を、そのお客様のコンピューター（PCやスマートフォン、タブレットなどインターネット接続可能な機器）に記憶させる機能のことです。
-  </p>
+    <p>
+      クッキーとはお客様のウェブサイト閲覧情報を、そのお客様のコンピューター（PCやスマートフォン、タブレットなどインターネット接続可能な機器）に記憶させる機能のことです。
+    </p>
 
-  <p>
-    クッキーには、当団によって設定されるもの（ファーストパーティークッキー）と、当団と提携する第三者によって設定されるもの（サードパーティークッキー）があります。
-  </p>
+    <p>
+      クッキーには、当団によって設定されるもの（ファーストパーティークッキー）と、当団と提携する第三者によって設定されるもの（サードパーティークッキー）があります。
+    </p>
 
-  <h3>2. クッキーの利用目的</h3>
+    <h2>2. クッキーの利用目的</h2>
 
-  <ol>
-    <li>
-      <p>
-        当団では、クッキーを使用して収集した情報を利用して、お客様のウェブサイトの利用状況（アクセス状況、トラフィック、ルーティング等）を分析し、ウェブサイト自体のパフォーマンス改善や、当団からお客様に提供するサービスの向上、改善のために使用することがあります。
-      </p>
-      <p>
-        また、この分析にあたっては、主に以下のツールが利用され、ツール提供者に情報提供されることがあります。
-      </p>
-      <ul>
-        <li>Google Analytics</li>
-        <li>Microsoft Clarify</li>
-      </ul>
-    </li>
-  </ol>
+    <ol>
+      <li>
+        <p>
+          当団では、クッキーを使用して収集した情報を利用して、お客様のウェブサイトの利用状況（アクセス状況、トラフィック、ルーティング等）を分析し、ウェブサイト自体のパフォーマンス改善や、当団からお客様に提供するサービスの向上、改善のために使用することがあります。
+        </p>
+        <p>
+          また、この分析にあたっては、主に以下のツールが利用され、ツール提供者に情報提供されることがあります。
+        </p>
+        <ul>
+          <li>Google Analytics</li>
+          <li>Microsoft Clarity</li>
+        </ul>
+      </li>
+    </ol>
 
-  <h3>3. クッキーの拒否方法</h3>
+    <h2>3. クッキーの拒否方法</h2>
 
-  <p>画面下部の「Cookieの設定を変更」のリンクより、クッキーを拒否することが可能です。</p>
+    <p>画面下部の「Cookieの設定を変更」のリンクより、クッキーを拒否することが可能です。</p>
 
-  <p>
-    また、お客様がブラウザの設定を変更することによりクッキーを無効にすることが可能です。ただし、クッキーを無効にした場合は、一部のサービスが受けられない場合があります。
-    <br />
-    クッキーの設定の変更方法については、各ブラウザの製造元へご確認ください。
-  </p>
+    <p>
+      また、お客様がブラウザの設定を変更することによりクッキーを無効にすることが可能です。ただし、クッキーを無効にした場合は、一部のサービスが受けられない場合があります。
+      <br />
+      クッキーの設定の変更方法については、各ブラウザの製造元へご確認ください。
+    </p>
 
-  <h3>4. サードパーティークッキーによる送信情報</h3>
+    <h2>4. サードパーティークッキーによる送信情報</h2>
 
-  <p>
-    本サービスでは、アクセス解析の目的で、サードパーティークッキーを使用しています。
-    <br />
-    サードパーティークッキーによる送信情報等は以下のとおりです。
-  </p>
+    <p>
+      本サービスでは、アクセス解析の目的で、サードパーティークッキーを使用しています。
+      <br />
+      サードパーティークッキーによる送信情報等は以下のとおりです。
+    </p>
 
-  <div class="horizontal-scroll">
-    <table>
-      <thead>
-        <tr>
-          <th>サービス名</th>
-          <th>クッキー名</th>
-          <th>送信先</th>
-          <th>当団での利用目的</th>
-          <th>送信先での利用目的</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Google Analytics</td>
-          <td>
-            <pre>_ga</pre>
-            /
-            <pre>_ga_xxxxxxxxxx</pre>
-          </td>
-          <td>
-            Google LLC<br />
-            及びその関係会社
-          </td>
-          <td>
-            利用者による閲覧の傾向や履歴の分析のため。<br />
-            詳細は
-            <a href="https://policies.google.com/privacy?hl=ja#whycollect">Googleのウェブサイト</a> をご参照ください。
-          </td>
-          <td>同左</td>
-        </tr>
-        <tr>
-          <td>Microsoft Clarity</td>
-          <td>
-            <pre>_clck</pre>
-            /
-            <pre>_clsk</pre>
-            /
-            <pre>CLID</pre>
-            /
-            <pre>ANONCHK</pre>
-            /
-            <pre>MR</pre>
-            /
-            <pre>MUID</pre>
-            /
-            <pre>SM</pre>
-          </td>
-          <td>
-            Microsoft Corporation<br />
-            及びその関連会社
-          </td>
-          <td>
-            利用者による閲覧の傾向や履歴の分析のため。<br />
-            詳細は
-            <a href="https://clarity.microsoft.com/terms">Microsoftのウェブサイト</a> をご参照ください。
-          </td>
-          <td>同左</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+    <div class="horizontal-scroll">
+      <table>
+        <thead>
+          <tr>
+            <th>サービス名</th>
+            <th>クッキー名</th>
+            <th>送信先</th>
+            <th>当団での利用目的</th>
+            <th>送信先での利用目的</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Google Analytics</td>
+            <td>
+              <pre>_ga</pre>
+              /
+              <pre>_ga_xxxxxxxxxx</pre>
+            </td>
+            <td>
+              Google LLC<br />
+              及びその関係会社
+            </td>
+            <td>
+              利用者による閲覧の傾向や履歴の分析のため。<br />
+              詳細は
+              <a href="https://policies.google.com/privacy?hl=ja#whycollect">Googleのウェブサイト</a
+              > をご参照ください。
+            </td>
+            <td>同左</td>
+          </tr>
+          <tr>
+            <td>Microsoft Clarity</td>
+            <td>
+              <pre>_clck</pre>
+              /
+              <pre>_clsk</pre>
+              /
+              <pre>CLID</pre>
+              /
+              <pre>ANONCHK</pre>
+              /
+              <pre>MR</pre>
+              /
+              <pre>MUID</pre>
+              /
+              <pre>SM</pre>
+            </td>
+            <td>
+              Microsoft Corporation<br />
+              及びその関連会社
+            </td>
+            <td>
+              利用者による閲覧の傾向や履歴の分析のため。<br />
+              詳細は
+              <a href="https://clarity.microsoft.com/terms">Microsoftのウェブサイト</a> をご参照ください。
+            </td>
+            <td>同左</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-  <p class="align-right">以上</p>
+    <p class="align-right">以上</p>
+  </article>
 </main>
 
 <style>
-  h2 {
+  .page-heading {
+    padding: clamp(36px, 7vw, 88px) 0 clamp(32px, 6vw, 72px);
+  }
+
+  .page-heading p {
+    margin: 0 0 calc(var(--spacing-unit) * 5);
+    color: var(--color-text-secondary);
+    font-family: var(--display-font);
+    font-size: 0.72rem;
+  }
+
+  h1 {
     margin: 0;
-    font-size: 2.2rem;
-  }
-  @media (max-width: 576px) {
-    h2 {
-      font-size: 2rem;
-    }
+    font-family: var(--serif);
+    font-size: 2.4rem;
+    font-weight: 500;
   }
 
-  main {
-    * {
-      letter-spacing: 0.04em;
-    }
+  article {
+    max-width: 900px;
+    font-family: var(--serif);
+    line-height: 1.9;
+  }
 
-    h3 {
-      margin-top: calc(var(--spacing-unit) * 12);
-      font-size: 1.5em;
-    }
+  article h2 {
+    max-width: var(--reading-max-width);
+    margin: calc(var(--spacing-unit) * 16) 0 calc(var(--spacing-unit) * 6);
+    border-top: 1px solid var(--color-border);
+    padding-top: calc(var(--spacing-unit) * 6);
+    font-size: 1.35rem;
+    font-weight: 600;
+  }
 
-    p {
-      text-align: justify;
-      line-height: 1.75;
-    }
+  article p,
+  article > ol {
+    max-width: var(--reading-max-width);
+  }
+
+  article p {
+    text-align: left;
   }
 
   .align-right {
@@ -155,28 +177,31 @@
 
   .horizontal-scroll {
     overflow: auto;
-    white-space: nowrap;
     display: flex;
+    max-width: 100%;
+    margin: calc(var(--spacing-unit) * 8) 0;
+    border: 1px solid var(--color-border);
   }
 
   table {
     border-collapse: collapse;
-    border-top: 2px solid;
-    border-bottom: 2px solid;
     flex-shrink: 0;
+    min-width: 920px;
+    font-family: var(--sans-serif);
+    font-size: 0.82rem;
   }
 
   thead {
-    border-bottom: 2px solid;
+    background: var(--color-surface-raised);
   }
 
   th,
   td {
-    border: 1px solid #ccc;
-    padding: 5px 15px;
-    text-align: center;
-    vertical-align: middle;
-    text-wrap: balance;
+    border: 1px solid var(--color-border);
+    padding: calc(var(--spacing-unit) * 3) calc(var(--spacing-unit) * 4);
+    text-align: left;
+    vertical-align: top;
+    white-space: normal;
   }
 
   td:nth-child(2) {
@@ -186,9 +211,20 @@
   td pre {
     display: inline;
     margin: 0;
+    color: var(--color-text-primary);
   }
 
   td a {
     text-decoration: underline;
+  }
+
+  @media (max-width: 600px) {
+    h1 {
+      font-size: 1.8rem;
+    }
+
+    article h2 {
+      font-size: 1.15rem;
+    }
   }
 </style>

--- a/src/routes/post/[slug]/+page.svelte
+++ b/src/routes/post/[slug]/+page.svelte
@@ -1,20 +1,30 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import Flyer from '$lib/component/Flyer.svelte';
+  import Meta from '$lib/component/Meta.svelte';
   import TagList from '$lib/component/TagList.svelte';
   import { getFullTitle } from '$lib/posts';
   import { composers } from '$lib/posts/composers';
   import { concerts } from '$lib/posts/concerts';
   import { formatDate2JpStyle } from '$lib/util';
-  import type { PageData } from './$types';
   import type { Composer } from '$lib/posts/composers';
-  import Meta from '$lib/component/Meta.svelte';
-  import Flyer from '$lib/component/Flyer.svelte';
+  import type { PageData } from './$types';
 
   interface Props {
     data: PageData;
   }
 
+  type TableOfContentsEntry = {
+    id: string;
+    level: 3 | 4;
+    title: string;
+  };
+
   let { data }: Props = $props();
+  let articleBody: HTMLElement;
+  let tableOfContents = $state<TableOfContentsEntry[]>([]);
+  let authors = $state<string[]>([]);
+
   let metadata = $derived(data.post.metadata);
   let composer = $derived(metadata.composerSlug ? composers[metadata.composerSlug] : null);
   let arranger = $derived(metadata.arrangerSlug ? composers[metadata.arrangerSlug] : null);
@@ -23,352 +33,810 @@
   const hasYearOfDeath = (composer: Composer): composer is Composer & { yearOfDeath: number } => {
     return Object.keys(composer).includes('yearOfDeath');
   };
+
+  const todayInJapan = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).format(new Date());
+  const concertsByDate = [...Object.values(concerts)].sort((a, b) => a.date.localeCompare(b.date));
+  const upcomingConcert = concertsByDate.find((item) => item.date >= todayInJapan);
+  const featuredConcert = upcomingConcert ?? concertsByDate.at(-1)!;
+  const featuredConcertLabel = upcomingConcert ? 'NEXT CONCERT' : 'LATEST CONCERT';
+
+  $effect(() => {
+    const slug = data.slug;
+    const headings = Array.from(articleBody.querySelectorAll<HTMLHeadingElement>('h3, h4'));
+    tableOfContents = headings.map((heading, index) => {
+      const id = heading.id || `${slug}-section-${index + 1}`;
+      heading.id = id;
+
+      return {
+        id,
+        level: heading.tagName === 'H3' ? 3 : 4,
+        title: heading.textContent?.replace(/\s+/g, ' ').trim() || `セクション ${index + 1}`
+      };
+    });
+
+    authors = Array.from(articleBody.querySelectorAll<HTMLElement>('.post-author'))
+      .map((author) => author.textContent?.replace(/[（）]/g, '').trim() ?? '')
+      .filter((author, index, allAuthors) => author !== '' && allAuthors.indexOf(author) === index);
+  });
 </script>
 
 <Meta title={getFullTitle(data.post)} canonical={`/post/${data.slug}`} />
 
-<div class="meta meta-container for-small-screen">
-  <div></div>
-  <div class="date">{formatDate2JpStyle(metadata.publicatedAt)}</div>
-</div>
+<main class="article-page">
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <ol>
+      <li><a href={resolve('/')}>PROGRAM NOTES</a></li>
+      <li><a href={concert.url} rel="external">{concert.title}演奏会</a></li>
+      <li aria-current="page">{metadata.title}</li>
+    </ol>
+  </nav>
 
-<div class="meta meta-container">
-  <TagList tags={metadata.tags} />
-  <div class="date for-large-screen">{formatDate2JpStyle(metadata.publicatedAt)}</div>
-</div>
+  <header class="article-header">
+    <p class="eyebrow">PROGRAM NOTE</p>
+    <h1>{metadata.title}</h1>
 
-<h2>
-  {metadata.title}
-</h2>
+    {#if arranger && composer}
+      <p class="composer-name">{composer.fullName} <span>／ {arranger.fullName} 編</span></p>
+    {:else if composer}
+      <p class="composer-name">
+        {composer.fullName}
+        <span>
+          ／ {composer.yearOfBirth}&ndash;{#if hasYearOfDeath(composer)}{composer.yearOfDeath}{/if}
+        </span>
+      </p>
+    {/if}
 
-{#if arranger && composer}
-  <p class="composer">
-    {composer.fullName} ({arranger.fullName} 編)
-  </p>
-{:else if composer}
-  <p class="composer">
-    {composer.fullName} ({composer.yearOfBirth}&ndash;{#if hasYearOfDeath(composer)}{composer.yearOfDeath}{/if})
-  </p>
-{/if}
-
-<main>
-  <data.post.default />
-
-  {#if metadata.youTubeVideoIds}
-    <div class="video">
-      {#each metadata.youTubeVideoIds as id (id)}
-        <iframe
-          width="560"
-          height="315"
-          style="max-width: 100%;"
-          src={`https://www.youtube-nocookie.com/embed/${id}`}
-          title="YouTube video player"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen
-        ></iframe>
-      {/each}
+    <div class="article-metadata">
+      <div>
+        <span class="metadata-label">CONCERT</span>
+        <a href={concert.url} rel="external">{concert.title}演奏会</a>
+      </div>
+      <div>
+        <span class="metadata-label">CONCERT DATE</span>
+        <time datetime={concert.date}>{formatDate2JpStyle(concert.date)}</time>
+      </div>
+      <div>
+        <span class="metadata-label">PUBLISHED</span>
+        <time datetime={metadata.publicatedAt}>{formatDate2JpStyle(metadata.publicatedAt)}</time>
+      </div>
+      {#if data.post.hasAuthorCredit}
+        <div class:metadata-pending={authors.length === 0}>
+          <span class="metadata-label">TEXT</span>
+          <span>{authors.join(' ／ ')}</span>
+        </div>
+      {/if}
     </div>
+
+    <div class="article-tags">
+      <TagList tags={metadata.tags} />
+    </div>
+  </header>
+
+  {#if data.post.hasTableOfContents}
+    <details class="mobile-toc" class:toc-pending={tableOfContents.length === 0}>
+      <summary>目次</summary>
+      {#if tableOfContents.length > 0}
+        <ol>
+          {#each tableOfContents as entry (entry.id)}
+            <li class:toc-subsection={entry.level === 4}>
+              <a href={`#${entry.id}`}>{entry.title}</a>
+            </li>
+          {/each}
+        </ol>
+      {/if}
+    </details>
   {/if}
+
+  <div class="reading-layout">
+    <aside class="desktop-toc" aria-label="目次">
+      {#if tableOfContents.length > 0}
+        <p>CONTENTS</p>
+        <ol>
+          {#each tableOfContents as entry (entry.id)}
+            <li class:toc-subsection={entry.level === 4}>
+              <a href={`#${entry.id}`}>{entry.title}</a>
+            </li>
+          {/each}
+        </ol>
+      {/if}
+    </aside>
+
+    <article bind:this={articleBody} class="reading-body">
+      <h2 class="sr-only">曲目解説本文</h2>
+      <data.post.default />
+
+      {#if metadata.youTubeVideoIds}
+        <div class="video-list">
+          {#each metadata.youTubeVideoIds as id, index (id)}
+            <iframe
+              src={`https://www.youtube-nocookie.com/embed/${id}`}
+              title={`${metadata.title} 関連動画 ${index + 1}`}
+              loading="lazy"
+              referrerpolicy="strict-origin-when-cross-origin"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
+          {/each}
+        </div>
+      {/if}
+    </article>
+  </div>
+
+  {#if data.relatedPostListItems.sameConcert.length > 0}
+    <section class="related-notes" aria-labelledby="same-concert-heading">
+      <p class="section-label">PROGRAM</p>
+      <h2 id="same-concert-heading">同じ演奏会の曲目</h2>
+      <div class="related-list">
+        {#each data.relatedPostListItems.sameConcert as post (post.slug)}
+          <a href={resolve('/post/[slug]', { slug: post.slug })}>
+            <span>{getFullTitle(post)}</span>
+            <time datetime={post.metadata.publicatedAt}>
+              {formatDate2JpStyle(post.metadata.publicatedAt)}
+            </time>
+          </a>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  {#if data.relatedPostListItems.sameComposer.length > 0}
+    <section class="related-notes compact" aria-labelledby="same-composer-heading">
+      <p class="section-label">MORE NOTES</p>
+      <h2 id="same-composer-heading">同じ作曲家の曲目解説</h2>
+      <div class="related-list">
+        {#each data.relatedPostListItems.sameComposer as post (post.slug)}
+          <a href={resolve('/post/[slug]', { slug: post.slug })}>
+            <span>{getFullTitle(post)}</span>
+            <time datetime={post.metadata.publicatedAt}>
+              {formatDate2JpStyle(post.metadata.publicatedAt)}
+            </time>
+          </a>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  <section class="concert-band" aria-labelledby="featured-concert-heading">
+    <div class="concert-band-inner">
+      <a class="concert-flyer" href={featuredConcert.url} rel="external">
+        <Flyer src={featuredConcert.flyer} alt={`${featuredConcert.title}演奏会のフライヤー`} />
+      </a>
+      <div class="concert-details">
+        <p class="section-label">{featuredConcertLabel}</p>
+        <h2 id="featured-concert-heading">{featuredConcert.title}演奏会</h2>
+        <p>Orchestra Canvas Tokyo</p>
+        <time datetime={featuredConcert.date}>{formatDate2JpStyle(featuredConcert.date)}</time>
+        <a class="concert-link" href={featuredConcert.url} rel="external">演奏会詳細</a>
+      </div>
+    </div>
+  </section>
 </main>
 
-<div class="fullwidth-gray-background">
-  <section class="upcoming-concerts">
-    <h3>次回演奏会のご案内</h3>
-
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      fill="currentColor"
-      class="megaphone"
-      viewBox="0 0 16 16"
-    >
-      <path
-        d="M13 2.5a1.5 1.5 0 0 1 3 0v11a1.5 1.5 0 0 1-3 0zm-1 .724c-2.067.95-4.539 1.481-7 1.656v6.237a25 25 0 0 1 1.088.085c2.053.204 4.038.668 5.912 1.56zm-8 7.841V4.934c-.68.027-1.399.043-2.008.053A2.02 2.02 0 0 0 0 7v2c0 1.106.896 1.996 1.994 2.009l.496.008a64 64 0 0 1 1.51.048m1.39 1.081q.428.032.85.078l.253 1.69a1 1 0 0 1-.983 1.187h-.548a1 1 0 0 1-.916-.599l-1.314-2.48a66 66 0 0 1 1.692.064q.491.026.966.06"
-      />
-    </svg>
-
-    <p>
-      Orchestra Canvas Tokyo<br />第17回定期演奏会
-    </p>
-    <p>
-      2026年9月12日(土)<br />
-      横浜みなとみらいホール 大ホール
-    </p>
-    <p>指揮：田代 俊文</p>
-
-    <hr />
-
-    <p>
-      リヒャルト・シュトラウス<br />
-      アルプス交響曲 作品64
-    </p>
-
-    <hr />
-
-    <p>
-      詳細は<a href="https://www.orch-canvas.tokyo/concerts/regular-17">当団ホームページ</a>にて
-    </p>
-
-    <a href={concerts['regular-17'].url} rel="external">
-      <Flyer src={concerts['regular-17'].flyer} alt="第17回定期演奏会のフライヤー" />
-    </a>
-  </section>
-</div>
-
-<div class="adjacent-posts">
-  {#if data.adjacentPostListItems.prev !== null}
-    <a href={resolve('/post/[slug]', { slug: data.adjacentPostListItems.prev.slug })} class="prev">
-      前の投稿<br />
-      {getFullTitle(data.adjacentPostListItems.prev)}
-    </a>
-  {/if}
-  {#if data.adjacentPostListItems.next !== null}
-    <a href={resolve('/post/[slug]', { slug: data.adjacentPostListItems.next.slug })} class="next">
-      次の投稿<br />
-      {getFullTitle(data.adjacentPostListItems.next)}
-    </a>
-  {/if}
-</div>
-
-<div class="concert">
-  <a href={concert.url} rel="external">
-    <p>{concert.title}演奏会<br />{formatDate2JpStyle(concert.date)}</p>
-    <Flyer src={concert.flyer} alt={`${concert.title}のフライヤー`} />
-  </a>
-</div>
-
 <style>
-  @media (max-width: 576px) {
-    .for-large-screen {
-      display: none !important;
-    }
-  }
-  @media (min-width: 577px) {
-    .for-small-screen {
-      display: none !important;
-    }
-  }
-
-  .meta {
-    font-size: 0.85em;
-    font-family: var(--sans-serif);
-    color: var(--color-text-secondary);
-  }
-  .meta-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
+  .article-page {
     width: 100%;
+    color: var(--color-text-primary);
+    letter-spacing: 0;
   }
 
-  h2 {
-    margin: 0;
-    font-family: var(--serif);
-    font-size: 2.2rem;
-  }
-  @media (max-width: 576px) {
-    h2 {
-      font-size: 2rem;
-    }
-  }
-
-  .composer {
-    margin-top: 0;
-    margin-bottom: calc(var(--spacing-unit) * 8);
-    text-align: right;
-    font-family: var(--serif);
+  .breadcrumb,
+  .article-header,
+  .reading-layout,
+  .mobile-toc,
+  .related-notes,
+  .concert-band-inner {
+    width: min(100%, var(--content-max-width));
+    margin-inline: auto;
   }
 
-  .video {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: calc(var(--spacing-unit) * 8);
-    margin-top: calc(var(--spacing-unit) * 20);
+  .breadcrumb {
+    margin-bottom: calc(var(--spacing-unit) * 14);
+    color: var(--color-text-secondary);
+    font-family: var(--sans-serif);
+    font-size: 0.7rem;
   }
 
-  .adjacent-posts {
+  .breadcrumb ol {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
-    gap: calc(var(--spacing-unit) * 8);
-    margin-top: calc(var(--spacing-unit) * 20);
-    font-family: var(--serif);
-  }
-  .prev {
-    margin-left: 2em;
-  }
-  .next {
-    margin-right: 2em;
-    margin-left: auto;
-    text-align: right;
-  }
-  .prev,
-  .next {
-    position: relative;
-    display: inline-block;
-  }
-  .prev::before,
-  .next::after {
-    content: '';
-    width: 1em;
-    height: 1em;
-    margin-top: -0.5em;
-    border-top: solid 1px currentColor;
-    border-right: solid 1px currentColor;
-    position: absolute;
-    top: 50%;
-  }
-  .prev::before {
-    transform: rotate(225deg);
-    left: -1.5em;
-  }
-  .next::after {
-    transform: rotate(45deg);
-    right: -1.5em;
+    gap: calc(var(--spacing-unit) * 2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
 
-  .concert {
+  .breadcrumb li {
     display: flex;
-    flex-direction: column;
+    min-width: 0;
     align-items: center;
-    margin: calc(var(--spacing-unit) * 20) 0;
-    text-align: center;
+    gap: calc(var(--spacing-unit) * 2);
+  }
+
+  .breadcrumb li:not(:last-child)::after {
+    content: '/';
+    color: var(--color-border);
+  }
+
+  .breadcrumb li:last-child {
+    overflow: hidden;
+    max-width: 32ch;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .breadcrumb a,
+  .article-metadata a,
+  .desktop-toc a,
+  .mobile-toc a {
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.25em;
+    transition:
+      color 160ms ease,
+      text-decoration-color 160ms ease;
+  }
+
+  .breadcrumb a:hover,
+  .article-metadata a:hover,
+  .desktop-toc a:hover,
+  .mobile-toc a:hover {
+    text-decoration-color: currentColor;
+  }
+
+  .article-header {
+    padding-bottom: calc(var(--spacing-unit) * 14);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .eyebrow,
+  .section-label,
+  .metadata-label,
+  .desktop-toc > p {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-family: var(--display-font);
+    font-size: 0.68rem;
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+
+  h1 {
+    max-width: 20ch;
+    margin: calc(var(--spacing-unit) * 4) 0 0;
+    overflow-wrap: anywhere;
     font-family: var(--serif);
+    font-size: 3rem;
+    font-weight: 500;
+    line-height: 1.35;
+    letter-spacing: 0;
   }
-  .concert a {
-    padding: calc(var(--spacing-unit) * 4);
-    transition: background-color 0.3s;
+
+  .composer-name {
+    margin: calc(var(--spacing-unit) * 5) 0 0;
+    color: var(--color-text-secondary);
+    font-family: var(--serif);
+    font-size: 1rem;
+    line-height: 1.8;
+    letter-spacing: 0;
   }
-  .concert a:hover {
-    background-color: var(--color-background-secondary);
+
+  .composer-name span {
+    font-size: 0.82em;
+  }
+
+  .article-metadata {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: calc(var(--spacing-unit) * 7);
+    margin-top: calc(var(--spacing-unit) * 12);
+    font-family: var(--sans-serif);
+    font-size: 0.78rem;
+    line-height: 1.6;
+  }
+
+  .article-metadata > div {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 1.5);
+  }
+
+  .metadata-pending {
+    visibility: hidden;
+  }
+
+  .article-tags {
+    margin-top: calc(var(--spacing-unit) * 7);
+    color: var(--color-text-secondary);
+    font-family: var(--sans-serif);
+    font-size: 0.75rem;
+  }
+
+  .reading-layout {
+    display: grid;
+    grid-template-columns: minmax(150px, 210px) minmax(0, var(--reading-max-width));
+    gap: calc(var(--spacing-unit) * 14);
+    justify-content: center;
+    margin-top: calc(var(--spacing-unit) * 16);
+  }
+
+  .desktop-toc {
+    position: sticky;
+    top: calc(var(--spacing-unit) * 8);
+    align-self: start;
+    max-height: calc(100vh - var(--spacing-unit) * 16);
+    overflow-y: auto;
+    padding-top: calc(var(--spacing-unit) * 2);
+    color: var(--color-text-secondary);
+    font-family: var(--sans-serif);
+    font-size: 0.7rem;
+    line-height: 1.55;
+    scrollbar-width: thin;
+  }
+
+  .desktop-toc ol,
+  .mobile-toc ol {
+    margin: calc(var(--spacing-unit) * 4) 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .desktop-toc li + li,
+  .mobile-toc li + li {
+    margin-top: calc(var(--spacing-unit) * 2.5);
+  }
+
+  .desktop-toc .toc-subsection,
+  .mobile-toc .toc-subsection {
+    padding-inline-start: 1em;
+    color: var(--color-text-secondary);
+  }
+
+  .mobile-toc {
+    display: none;
+  }
+
+  .toc-pending {
+    visibility: hidden;
+  }
+
+  .reading-body {
+    min-width: 0;
+    max-width: var(--reading-max-width);
+    font-family: var(--serif);
+    font-size: 1rem;
+    line-height: 1.95;
+    letter-spacing: 0;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .reading-body :global(*) {
+    letter-spacing: 0;
+  }
+
+  .reading-body :global(h3),
+  .reading-body :global(h4) {
+    scroll-margin-top: calc(var(--spacing-unit) * 8);
+    overflow-wrap: anywhere;
+    font-family: var(--serif);
+    line-height: 1.55;
+  }
+
+  .reading-body :global(h3) {
+    margin: calc(var(--spacing-unit) * 18) 0 calc(var(--spacing-unit) * 6);
+    padding-top: calc(var(--spacing-unit) * 4);
+    border-top: 1px solid var(--color-border);
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+
+  .reading-body :global(h4) {
+    margin: calc(var(--spacing-unit) * 10) 0 calc(var(--spacing-unit) * 4);
+    font-size: 1.08rem;
+    font-weight: 600;
+  }
+
+  .reading-body :global(p) {
+    margin: calc(var(--spacing-unit) * 5) 0;
+    text-align: left;
+    text-indent: 1em;
+  }
+
+  .reading-body :global(a) {
+    border-radius: 1px;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.22em;
+    transition:
+      color 160ms ease,
+      background-color 160ms ease;
+  }
+
+  .reading-body :global(a:hover) {
+    background: var(--color-inverse-background);
+    color: var(--color-inverse-text);
     text-decoration: none;
   }
-  .concert p {
-    text-indent: 0;
-    margin: 0;
-    margin-bottom: calc(var(--spacing-unit) * 4);
+
+  .reading-body :global(blockquote) {
+    margin: calc(var(--spacing-unit) * 12) 0;
+    padding: calc(var(--spacing-unit) * 2) 0 calc(var(--spacing-unit) * 2)
+      calc(var(--spacing-unit) * 6);
+    border-inline-start: 1px solid var(--color-border);
+    color: var(--color-text-secondary);
+    font-style: normal;
   }
 
-  main {
+  .reading-body :global(blockquote p:first-child) {
+    margin-top: 0;
+  }
+
+  .reading-body :global(blockquote p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .reading-body :global(ul),
+  .reading-body :global(ol) {
+    padding-inline-start: 1.5em;
+  }
+
+  .reading-body :global(li + li) {
+    margin-top: calc(var(--spacing-unit) * 2);
+  }
+
+  .reading-body :global(figure:has(blockquote)) {
     margin: calc(var(--spacing-unit) * 12) 0;
   }
 
-  /* 本文に対するスタイル */
-  main {
-    :global(*) {
-      font-family: var(--serif);
-      letter-spacing: 0.04em;
-    }
-
-    :global(h3) {
-      margin-top: calc(var(--spacing-unit) * 12);
-      font-size: 1.5em;
-    }
-    :global(h4) {
-      margin-top: calc(var(--spacing-unit) * 8);
-      margin-bottom: 0;
-      font-size: 1.1em;
-    }
-
-    :global(p) {
-      text-indent: 1rem;
-      text-align: justify;
-      line-height: 1.75;
-    }
-
-    :global(blockquote) {
-      margin-top: calc(var(--spacing-unit) * 12);
-      margin-bottom: calc(var(--spacing-unit) * 12);
-      font-style: italic;
-      text-indent: 1em;
-    }
-    :global(blockquote h4) {
-      text-indent: 0;
-    }
-
-    @media (max-width: 576px) {
-      :global(blockquote) {
-        margin-right: 1em;
-        margin-left: 1em;
-      }
-    }
-
-    :global(li:not(li:last-child)) {
-      margin-bottom: calc(var(--spacing-unit) * 2);
-    }
-
-    /* 引用元が示されている引用に対するスタイル
-		figure	-> blockquote
-				-> figcaption */
-    :global(figure:has(blockquote)) {
-      margin: calc(var(--spacing-unit) * 12) 1em;
-    }
-    :global(figure blockquote) {
-      margin: initial;
-    }
-    :global(figure:has(blockquote) > figcaption) {
-      text-align: right;
-      font-size: 0.85em;
-    }
+  .reading-body :global(figure blockquote) {
+    margin: 0;
   }
 
-  /* 次回演奏会に対するスタイル */
-  .fullwidth-gray-background {
-    display: flex;
-    justify-content: center;
-    margin: calc(var(--spacing-unit) * 20) calc(-1 * var(--spacing-unit) * 8) 0;
-    padding: calc(var(--spacing-unit) * 6) 0;
-    background-color: var(--color-background-secondary);
-
-    @media (max-width: 576px) {
-      margin: calc(var(--spacing-unit) * 20) calc(-1 * var(--spacing-unit) * 6) 0;
-    }
+  .reading-body :global(figure:has(blockquote) > figcaption) {
+    margin-top: calc(var(--spacing-unit) * 3);
+    color: var(--color-text-secondary);
+    font-family: var(--sans-serif);
+    font-size: 0.75rem;
+    line-height: 1.6;
+    text-align: right;
   }
 
-  .upcoming-concerts {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+  .reading-body :global(hr) {
+    margin: calc(var(--spacing-unit) * 12) 0;
+    border: 0;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .reading-body :global(table) {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    border-collapse: collapse;
+  }
+
+  .reading-body :global(th),
+  .reading-body :global(td) {
+    padding: calc(var(--spacing-unit) * 2);
+    border-bottom: 1px solid var(--color-border);
+    text-align: left;
+  }
+
+  .video-list {
+    display: grid;
+    gap: calc(var(--spacing-unit) * 8);
+    margin-top: calc(var(--spacing-unit) * 18);
+  }
+
+  .video-list iframe {
+    display: block;
+    width: 100%;
+    height: auto;
+    aspect-ratio: 16 / 9;
+    border: 0;
+    background: var(--color-surface);
+  }
+
+  .related-notes {
+    margin-top: calc(var(--spacing-unit) * 28);
+  }
+
+  .related-notes.compact {
+    margin-top: calc(var(--spacing-unit) * 18);
+  }
+
+  .related-notes h2,
+  .concert-details h2 {
+    margin: calc(var(--spacing-unit) * 2) 0 calc(var(--spacing-unit) * 7);
+    font-family: var(--serif);
+    font-size: 1.7rem;
+    font-weight: 500;
+    line-height: 1.5;
+    letter-spacing: 0;
+  }
+
+  .related-list {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .related-list a {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: calc(var(--spacing-unit) * 6);
+    align-items: baseline;
+    padding: calc(var(--spacing-unit) * 5) calc(var(--spacing-unit) * 2);
+    border-bottom: 1px solid var(--color-border);
+    font-family: var(--serif);
+    line-height: 1.6;
+    text-decoration: none;
+    transition:
+      color 160ms ease,
+      background-color 160ms ease;
+  }
+
+  .related-list a:hover {
+    background: var(--color-inverse-background);
+    color: var(--color-inverse-text);
+  }
+
+  .related-list time {
+    color: var(--color-text-secondary);
+    font-family: var(--sans-serif);
+    font-size: 0.7rem;
+    white-space: nowrap;
+  }
+
+  .related-list a:hover time {
+    color: inherit;
+  }
+
+  .concert-band {
+    margin-top: calc(var(--spacing-unit) * 28);
+    padding: calc(var(--spacing-unit) * 12) 0;
+    border-top: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface);
+  }
+
+  .concert-band-inner {
+    display: grid;
+    grid-template-columns: minmax(140px, 220px) minmax(0, 1fr);
+    gap: calc(var(--spacing-unit) * 12);
     align-items: center;
-    gap: calc(var(--spacing-unit) * 2);
+  }
 
-    position: relative;
+  .concert-flyer {
+    display: block;
+    min-width: 0;
+    aspect-ratio: 1 / 1.4142;
+    transition: opacity 160ms ease;
+  }
 
-    border-radius: 10px;
-    padding: calc(var(--spacing-unit) * 6) calc(var(--spacing-unit) * 12);
-    width: min(300px, 50dvw);
+  .concert-flyer :global(img) {
+    max-height: none;
+  }
 
-    overflow: hidden;
+  .concert-flyer:hover {
+    opacity: 0.82;
+  }
 
-    background-color: #fff;
-    font-size: 90%;
-    text-align: center;
+  .concert-details {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: flex-start;
+  }
 
-    > * {
-      margin: 0;
-      z-index: 2;
+  .concert-details h2 {
+    margin-bottom: calc(var(--spacing-unit) * 2);
+    overflow-wrap: anywhere;
+  }
+
+  .concert-details > p:not(.section-label),
+  .concert-details time {
+    margin: 0;
+    font-family: var(--sans-serif);
+    font-size: 0.82rem;
+    line-height: 1.7;
+  }
+
+  .concert-details time {
+    color: var(--color-text-secondary);
+  }
+
+  .concert-link {
+    display: inline-block;
+    margin-top: calc(var(--spacing-unit) * 7);
+    padding: calc(var(--spacing-unit) * 2.5) calc(var(--spacing-unit) * 4);
+    border: 1px solid var(--color-border);
+    font-family: var(--sans-serif);
+    font-size: 0.72rem;
+    text-decoration: none;
+    transition:
+      color 160ms ease,
+      background-color 160ms ease,
+      border-color 160ms ease;
+  }
+
+  .concert-link:hover {
+    border-color: var(--color-inverse-background);
+    background: var(--color-inverse-background);
+    color: var(--color-inverse-text);
+  }
+
+  :is(a, summary):focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+  }
+
+  @media (max-width: 900px) {
+    .article-metadata {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    .megaphone {
-      position: absolute;
-      top: 60px;
-      right: 65px;
-      z-index: 1;
-
-      transform: rotate(-30deg) scale(5.9);
-      fill: var(--color-background-secondary);
+    .reading-layout {
+      grid-template-columns: minmax(0, var(--reading-max-width));
+      gap: 0;
     }
 
-    > h3,
-    > :global(picture) {
-      margin: calc(var(--spacing-unit) * 2) 0;
+    .desktop-toc {
+      display: none;
     }
 
-    a {
-      text-decoration: underline;
+    .mobile-toc {
+      display: block;
+      margin-top: calc(var(--spacing-unit) * 8);
+      border-top: 1px solid var(--color-border);
+      border-bottom: 1px solid var(--color-border);
+      color: var(--color-text-secondary);
+      font-family: var(--sans-serif);
+      font-size: 0.78rem;
+    }
+
+    .mobile-toc summary {
+      padding: calc(var(--spacing-unit) * 4) 0;
+      cursor: pointer;
+      color: var(--color-text-primary);
+      font-family: var(--display-font);
+      font-size: 0.72rem;
+      font-weight: 600;
+    }
+
+    .mobile-toc ol {
+      padding-bottom: calc(var(--spacing-unit) * 5);
+    }
+
+    .reading-layout {
+      margin-top: calc(var(--spacing-unit) * 12);
+    }
+  }
+
+  @media (max-width: 620px) {
+    .breadcrumb {
+      margin-bottom: calc(var(--spacing-unit) * 10);
+    }
+
+    .article-header {
+      padding-bottom: calc(var(--spacing-unit) * 10);
+    }
+
+    h1 {
+      max-width: none;
+      font-size: 2.15rem;
+      line-height: 1.45;
+    }
+
+    .composer-name {
+      font-size: 0.92rem;
+    }
+
+    .article-metadata {
+      grid-template-columns: 1fr;
+      gap: calc(var(--spacing-unit) * 4);
+      margin-top: calc(var(--spacing-unit) * 9);
+    }
+
+    .article-metadata > div {
+      display: grid;
+      grid-template-columns: 7.5rem minmax(0, 1fr);
+      gap: calc(var(--spacing-unit) * 3);
+    }
+
+    .article-metadata > div:last-child {
+      min-height: 3.2em;
+    }
+
+    .reading-body {
+      line-height: 1.9;
+    }
+
+    .reading-body :global(h3) {
+      margin-top: calc(var(--spacing-unit) * 14);
+      font-size: 1.32rem;
+    }
+
+    .reading-body :global(h4) {
+      font-size: 1rem;
+    }
+
+    .reading-body :global(blockquote) {
+      padding-inline-start: calc(var(--spacing-unit) * 4);
+    }
+
+    .related-notes {
+      margin-top: calc(var(--spacing-unit) * 22);
+    }
+
+    .related-notes h2,
+    .concert-details h2 {
+      font-size: 1.4rem;
+    }
+
+    .related-list a {
+      grid-template-columns: 1fr;
+      gap: calc(var(--spacing-unit) * 1.5);
+    }
+
+    .concert-band {
+      margin-top: calc(var(--spacing-unit) * 22);
+      padding: calc(var(--spacing-unit) * 8) 0;
+    }
+
+    .concert-band-inner {
+      grid-template-columns: minmax(82px, 105px) minmax(0, 1fr);
+      gap: calc(var(--spacing-unit) * 5);
+      align-items: start;
+    }
+
+    .concert-details h2 {
+      margin-top: calc(var(--spacing-unit) * 1.5);
+      font-size: 1.18rem;
+    }
+
+    .concert-details > p:not(.section-label),
+    .concert-details time {
+      font-size: 0.72rem;
+    }
+
+    .concert-link {
+      margin-top: calc(var(--spacing-unit) * 4);
+      padding: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 3);
+    }
+  }
+
+  @media (max-width: 360px) {
+    h1 {
+      font-size: 1.85rem;
+    }
+
+    .article-metadata > div {
+      grid-template-columns: 6.5rem minmax(0, 1fr);
+    }
+
+    .concert-band-inner {
+      grid-template-columns: 82px minmax(0, 1fr);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .article-page * {
+      scroll-behavior: auto !important;
+      transition-duration: 0.01ms !important;
     }
   }
 </style>

--- a/src/routes/post/[slug]/+page.ts
+++ b/src/routes/post/[slug]/+page.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 
-import { getAdjacentPostListItemsBySlug, getPostBySlug } from '$lib/posts';
+import { getPostBySlug, getRelatedPostListItemsBySlug } from '$lib/posts';
 
 import type { PageLoad } from './$types';
 
@@ -10,11 +10,11 @@ export const load: PageLoad = async ({ params }) => {
   if (post === null) error(404);
   if (!post.metadata.published) error(404);
 
-  const adjacentPostListItems = await getAdjacentPostListItemsBySlug(params.slug);
+  const relatedPostListItems = await getRelatedPostListItemsBySlug(params.slug);
 
   return {
     post: post,
     slug: params.slug,
-    adjacentPostListItems: adjacentPostListItems
+    relatedPostListItems
   };
 };

--- a/src/routes/tag/[tag=tag]/+page.svelte
+++ b/src/routes/tag/[tag=tag]/+page.svelte
@@ -12,11 +12,13 @@
 
 <Meta title={`#${data.tag}の記事一覧`} canonical={`/tag/${data.tag}`} />
 
-<SearchablePostList
-  heading={`#${data.tag}の記事一覧`}
-  summary={`${data.totalNumberOfPosts}件`}
-  posts={data.posts}
-  tag={data.tag}
-  currentPageNumber={data.currentPageNumber}
-  totalNumberOfPages={data.totalNumberOfPages}
-/>
+<main>
+  <SearchablePostList
+    heading={`#${data.tag}の記事一覧`}
+    summary={`${data.totalNumberOfPosts}件`}
+    posts={data.posts}
+    tag={data.tag}
+    currentPageNumber={data.currentPageNumber}
+    totalNumberOfPages={data.totalNumberOfPages}
+  />
+</main>


### PR DESCRIPTION
## Summary

- Align the blog shell, typography, spacing, and restrained dark palette with the Orchestra Canvas Tokyo homepage.
- Rework the archive around three useful views: latest notes, concert collections, and composer collections.
- Redesign article pages for long-form reading with responsive navigation, generated contents, author metadata, related notes, and concert context.
- Refine search, consent, tag, policy, error, and embedded-content states for accessibility and responsive behavior.
- Correct composer lifespan data, the Regular 7 concert date, stable calendar-date formatting, and featured-program ordering.

## Design direction

The implementation uses the main site's near-black foundation, white type, secondary gray, fine rules, and authentic concert flyers. It deliberately avoids decorative card layouts and keeps the program notes as the primary content.

## Verification

- `npm run precommit`
- `npm run build` with `@sveltejs/adapter-cloudflare`
- `git diff --check`
- Playwright interaction checks for search, focus restoration, client-side article navigation, TOC/author refresh, date behavior in a western timezone, and horizontal overflow
- Desktop and mobile screenshots for latest, concert, composer, article, and consent views
- Independent regression review with no material findings remaining

Cloudflare Pages should publish the branch preview through the repository's existing PR integration.